### PR TITLE
Feature: mint with seed

### DIFF
--- a/contracts/IEditionSingleMintable.sol
+++ b/contracts/IEditionSingleMintable.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.6;
 
+struct MintData {
+  address to;
+  uint256 seed;
+}
+
 interface IEditionSingleMintable {
   function mintEdition(address to) external returns (uint256);
-  function mintEdition(address to, uint256 seed) external returns (uint256);
+  function mintEditionWithSeed(address to, uint256 seed) external returns (uint256);
   function mintEditions(address[] memory to) external returns (uint256);
-  function mintEditions(address[] memory to, uint256[] memory seed) external returns (uint256);
+  function mintEditionsWithSeed(MintData[] memory to) external returns (uint256);
   function numberCanMint() external view returns (uint256);
   function owner() external view returns (address);
 }

--- a/contracts/IEditionSingleMintable.sol
+++ b/contracts/IEditionSingleMintable.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.6;
 
 interface IEditionSingleMintable {
   function mintEdition(address to) external returns (uint256);
+  function mintEdition(address to, uint256 seed) external returns (uint256);
   function mintEditions(address[] memory to) external returns (uint256);
+  function mintEditions(address[] memory to, uint256[] memory seed) external returns (uint256);
   function numberCanMint() external view returns (uint256);
   function owner() external view returns (address);
 }

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -75,12 +75,14 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         MediaData memory media,
         uint256 tokenOfEdition,
         uint256 editionSize,
-        address tokenAddress
+        address tokenAddress,
+        uint256 tokenSeed
     ) external pure returns (string memory) {
         string memory _tokenMediaData = tokenMediaData(
             media,
             tokenOfEdition,
-            tokenAddress
+            tokenAddress,
+            tokenSeed
         );
         bytes memory json = createMetadataJSON(
             name,
@@ -155,7 +157,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
     function tokenMediaData(
         MediaData memory media,
         uint256 tokenOfEdition,
-        address tokenAddress
+        address tokenAddress,
+        uint256 tokenSeed
     ) public pure returns (string memory) {
         bool hasImage = bytes(media.imageUrl).length > 0;
         bool hasAnimation = bytes(media.animationUrl).length > 0;
@@ -173,6 +176,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                         numberToString(tokenOfEdition),
                         "&address=",
                         addressToString(tokenAddress),
+                        "&seed=",
+                        numberToString(tokenSeed),
                         '", "',
                         'media_version": "',
                         uintArray3ToString(media.label),
@@ -205,6 +210,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                         numberToString(tokenOfEdition),
                         "&address=",
                         addressToString(tokenAddress),
+                        "&seed=",
+                        numberToString(tokenSeed),
                         '", "',
                         'media_version": "',
                         uintArray3ToString(media.label),

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -169,7 +169,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                         'image": "',
                         media.imageUrl,
                         "?id=",
-                        numberToString(tokenOfEdition),
+                        numberToString(tokenSeed),
                         '", "animation_url": "',
                         media.animationUrl,
                         "?id=",
@@ -192,7 +192,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                         'image": "',
                         media.imageUrl,
                         "?id=", // if just url "/id" this will work with arweave pathmanifests
-                        numberToString(tokenOfEdition),
+                        numberToString(tokenSeed),
                         '", "',
                         'media_version": "',
                         uintArray3ToString(media.label),

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -196,7 +196,6 @@ contract SingleEditionMintable is
      */
     function mintEdition(address to, uint256 seed) external override returns (uint256) {
         require(_isAllowedToMint(), "Needs to be an allowed minter");
-        require(seedsUsed[seed] == 0, "Seed already used");
         address[] memory toMint = new address[](1);
         toMint[0] = to;
         uint256[] memory toMintSeed = new uint256[](1);
@@ -324,6 +323,12 @@ contract SingleEditionMintable is
         uint256 endAt = startAt + recipients.length - 1;
         require(editionSize == 0 || endAt <= editionSize, "Sold out");
         while (atEditionId.current() <= endAt) {
+             // check if seed has been used
+            require(seedsUsed[atEditionId.current()] == 0, "Seed already used");
+
+            // allocate seed to id
+            seedsUsed[atEditionId.current()] = atEditionId.current();
+
             _mint(
                 recipients[atEditionId.current() - startAt],
                 atEditionId.current()
@@ -349,7 +354,7 @@ contract SingleEditionMintable is
             require(seedsUsed[seeds[atEditionId.current() - startAt]] == 0, "Seed already used");
 
             // allocate seed to id
-            seeds[seedsUsed[atEditionId.current() - startAt]] = atEditionId.current();
+            seedsUsed[ seeds[atEditionId.current() - startAt]] = atEditionId.current();
 
             _mint(
                 recipients[atEditionId.current() - startAt],

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -311,6 +311,10 @@ contract SingleEditionMintable is
         _burn(tokenId);
     }
 
+    function _isSeedInRange(uint256 seed) private view returns (bool) {
+        return ((seed > 0) && (seed < editionSize + 1));
+    }
+
     /**
       @dev Private function to mint als without any access checks.
            Called by the public edition minting functions.
@@ -352,6 +356,8 @@ contract SingleEditionMintable is
         while (atEditionId.current() <= endAt) {
             // check if seed has been used
             require(seedsUsed[seeds[atEditionId.current() - startAt]] == 0, "Seed already used");
+            // check if seed is out of range
+            require(_isSeedInRange(seeds[atEditionId.current() - startAt]), "Seed out of range");
 
             // allocate seed to id
             seedsUsed[ seeds[atEditionId.current() - startAt]] = atEditionId.current();

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -209,7 +209,8 @@ contract SingleEditionMintable is
     /**
       @param to address to send the newly minted edition to
       @param seed uint256 to seed newly minted edition with
-      @dev This mints one edition to the given address by an allowed minter on the edition instance.
+      @dev This mints one edition with given seed to the given address
+        by an allowed minter on the edition instance.
      */
     function mintEditionWithSeed(address to, uint256 seed) external override returns (uint256) {
         require(_isAllowedToMint(), "Needs to be an allowed minter");
@@ -325,14 +326,20 @@ contract SingleEditionMintable is
         _burn(tokenId);
     }
 
+
+    /**
+        @param seed uint256 of the seed
+        @dev  checks to see if seed is in valid range
+    */
     function _isSeedInRange(uint256 seed) private view returns (bool) {
         return ((seed > 0) && (seed < editionSize + 1));
     }
 
     /**
-      @dev Private function to find the next availble un-used seed closest to zero
+      @return uint256 next un-used seed
+      @dev Intenral function to find the next availble un-used seed closest to zero
      */
-    function _findNextSeed() private view returns (uint256) {
+    function _findNextSeed() internal view returns (uint256) {
         if(_lastUsedSeed == 0) return 1;
 
         uint256 next;
@@ -378,6 +385,7 @@ contract SingleEditionMintable is
     /**
       @dev Private function to mint als without any access checks.
            Called by the public edition minting functions.
+           allocates next availble seed
      */
     function _mintEditions(address[] memory recipients)
         internal
@@ -401,6 +409,7 @@ contract SingleEditionMintable is
     /**
       @dev Private function to mint als without any access checks.
            Called by the public edition minting functions.
+           allocates requested seeds
      */
     function _mintEditionsWithSeed(MintData[] memory recipients)
         internal

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -149,6 +149,21 @@ contract SingleEditionMintable is
     }
 
     /**
+      @dev This allows the user to purchase a edition with specific seed
+           at the given price in the contract.
+     */
+    function purchase(uint256 seed) external payable returns (uint256) {
+        require(salePrice > 0, "Not for sale");
+        require(msg.value == salePrice, "Wrong price");
+        address[] memory toMint = new address[](1);
+        toMint[0] = msg.sender;
+        uint256[] memory toMintSeed = new uint256[](1);
+        toMintSeed[0] = seed;
+        emit EditionSold(salePrice, msg.sender);
+        return _mintEditions(toMint, toMintSeed);
+    }
+
+    /**
       @param _salePrice if sale price is 0 sale is stopped, otherwise that amount 
                        of ETH is needed to start the sale.
       @dev This sets a simple ETH sales price

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -332,7 +332,7 @@ contract SingleEditionMintable is
         @dev  checks to see if seed is in valid range
     */
     function _isSeedInRange(uint256 seed) private view returns (bool) {
-        return ((seed > 0) && (seed < editionSize + 1));
+        return ((seed > 0) && (seed <= editionSize));
     }
 
     /**
@@ -343,7 +343,7 @@ contract SingleEditionMintable is
         if(_lastUsedSeed == 0) return 1;
 
         uint256 next;
-        for (uint256 i = _lastUsedSeed; i < editionSize; i++) {
+        for (uint256 i = _lastUsedSeed; i <= editionSize; i++) {
             if(seedsUsed[i] == false){
                 next = i;
                 break;

--- a/test/mint-with-seed.ts
+++ b/test/mint-with-seed.ts
@@ -197,6 +197,37 @@ describe.only("mint with seed feature", () => {
       )) as SingleEditionMintable;
     });
 
+    it("creates a set of editions", async () => {
+      const [s1, s2, s3] = await ethers.getSigners();
+
+      await minterContract.mintEditions(
+        [
+          await s1.getAddress(),
+          await s2.getAddress(),
+          await s3.getAddress(),
+        ],
+      );
+      expect(await minterContract.ownerOf(1)).to.equal(await s1.getAddress());
+      expect(await minterContract.ownerOf(2)).to.equal(await s2.getAddress());
+      expect(await minterContract.ownerOf(3)).to.equal(await s3.getAddress());
+
+      await minterContract.mintEditions(
+        [
+          await s1.getAddress(),
+          await s2.getAddress(),
+          await s3.getAddress(),
+          await s2.getAddress(),
+          await s3.getAddress(),
+          await s2.getAddress(),
+          await s3.getAddress(),
+        ]
+      );
+
+      await expect(
+        minterContract.mintEditions([signerAddress])
+      ).to.be.reverted;
+    });
+
     it("creates a set of editions with specific seeds", async () => {
       const [s1, s2, s3] = await ethers.getSigners();
 

--- a/test/mint-with-seed.ts
+++ b/test/mint-with-seed.ts
@@ -1,0 +1,232 @@
+// Note[George]: Quickly copied over relevant tests to check feature change
+// to only run this test use `yarn hardhat test ./test/mint-with-seed.ts`
+
+import { expect } from "chai";
+import "@nomiclabs/hardhat-ethers";
+import { ethers, deployments } from "hardhat";
+import parseDataURI from "data-urls";
+
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import {
+  SingleEditionMintableCreator,
+  SingleEditionMintable,
+} from "../typechain";
+import { BigNumberish } from "ethers";
+
+type Label = [BigNumberish, BigNumberish, BigNumberish]
+
+const defaultVersion = () => {
+  return {
+    urls: [
+      // image
+      {
+        url: "",
+        sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+      },
+      // animation
+      {
+        url: "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy",
+        sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      },
+    ],
+    label: [0,0,1] as Label
+  }
+}
+
+const toMintData = (to: string, id: BigNumberish) => ({to, id})
+
+const fetchMetadata = async (tokenId: number, contract: SingleEditionMintable) => {
+  const tokenURI = await contract.tokenURI(tokenId);
+  const parsedTokenURI = parseDataURI(tokenURI);
+  if (!parsedTokenURI) {
+    throw "No parsed token uri";
+  }
+
+  // parse metadata body
+  const uriData = Buffer.from(parsedTokenURI.body).toString("utf-8");
+  return JSON.parse(uriData);
+}
+
+describe.only("mint with seed feature", () => {
+  let signer: SignerWithAddress;
+  let signerAddress: string;
+  let dynamicSketch: SingleEditionMintableCreator;
+
+  beforeEach(async () => {
+    const { SingleEditionMintableCreator } = await deployments.fixture([
+      "SingleEditionMintableCreator",
+      "SingleEditionMintable",
+    ]);
+    const dynamicMintableAddress = (
+      await deployments.get("SingleEditionMintable")
+    ).address;
+    dynamicSketch = (await ethers.getContractAt(
+      "SingleEditionMintableCreator",
+      SingleEditionMintableCreator.address
+    )) as SingleEditionMintableCreator;
+
+    signer = (await ethers.getSigners())[0];
+    signerAddress = await signer.getAddress();
+  });
+
+  describe("with a edition", () => {
+    let signer1: SignerWithAddress;
+    let minterContract: SingleEditionMintable;
+    beforeEach(async () => {
+      signer1 = (await ethers.getSigners())[1];
+      await dynamicSketch.createEdition(
+        "Testing Token",
+        "TEST",
+        "This is a testing token for all",
+        defaultVersion(),
+        // 1% royalty since BPS
+        10,
+        10
+      );
+
+      const editionResult = await dynamicSketch.getEditionAtId(0);
+      minterContract = (await ethers.getContractAt(
+        "SingleEditionMintable",
+        editionResult
+      )) as SingleEditionMintable;
+    });
+
+    it("creates a new edition", async () => {
+      // Mint first edition
+      await expect(minterContract.mintEdition(signerAddress))
+        .to.emit(minterContract, "Transfer")
+        .withArgs(
+          "0x0000000000000000000000000000000000000000",
+          signerAddress,
+          1
+        );
+    });
+
+    it("creates new edition with seed", async () => {
+      const seed = 5
+      await expect(minterContract.mintEdition(signerAddress, seed)
+      ).to.emit(minterContract, "Transfer")
+        .withArgs(
+          "0x0000000000000000000000000000000000000000",
+          signerAddress,
+          1
+        );
+    });
+
+    it("auto assigns next available seed", async () => {
+      // TODO: read metadata and check seed number
+      const seed = 2
+
+      // with seed 2
+      await expect(minterContract.mintEdition(signerAddress, seed)
+      ).to.emit(minterContract, "Transfer")
+        .withArgs(
+          "0x0000000000000000000000000000000000000000",
+          signerAddress,
+          1
+        );
+
+      const metadata1 = await fetchMetadata(1, minterContract)
+
+      expect(
+        JSON.stringify(metadata1.animation_url)
+      ).to.equal(
+        "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=1"
+        + `&address=${minterContract.address.toLowerCase()}`
+        + `&seed=2`
+      );
+
+      // without seed - seed = 1
+      await expect(minterContract.mintEdition(signerAddress)
+      ).to.emit(minterContract, "Transfer")
+        .withArgs(
+          "0x0000000000000000000000000000000000000000",
+          signerAddress,
+          2
+        );
+
+      const metadata2 = await fetchMetadata(2, minterContract)
+
+      expect(
+        JSON.stringify(metadata2.animation_url)
+      ).to.equal(
+        "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=2"
+        + `&address=${minterContract.address.toLowerCase()}`
+        + `&seed=1`
+      );
+
+      // without seed - seed = 3
+      // seed should skip 2 becuase already used
+      await expect(minterContract.mintEdition(signerAddress)
+      ).to.emit(minterContract, "Transfer")
+        .withArgs(
+          "0x0000000000000000000000000000000000000000",
+          signerAddress,
+          3
+         );
+
+      const metadata3 = await fetchMetadata(3, minterContract)
+
+      expect(
+        JSON.stringify(metadata3.animation_url)
+      ).to.equal(
+        "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=3"
+        + `&address=${minterContract.address.toLowerCase()}`
+        + `&seed=3`
+      );
+    });
+
+    it("reverts if seed already used", async () => {
+      // Mint first edition - seed = 1
+      await expect(minterContract.mintEdition(signerAddress))
+        .to.emit(minterContract, "Transfer")
+        .withArgs(
+          "0x0000000000000000000000000000000000000000",
+          signerAddress,
+          1
+        );
+
+      await expect(minterContract.mintEdition(signerAddress, 1)
+      ).to.be.revertedWith("Seed already used")
+    });
+
+    it("reverts if seed out of range", async () => {
+      await expect(
+         minterContract.mintEdition(signerAddress, 0)
+      ).to.be.revertedWith("Edition id out of range")
+
+      await expect(
+         minterContract.mintEdition(signerAddress, 11)
+      ).to.be.revertedWith("Edition id out of range")
+    });
+
+    it("creates a set of editions with specific seeds", async () => {
+      const [s1, s2, s3] = await ethers.getSigners();
+      await minterContract.mintEditions(
+        [
+        await s1.getAddress(),
+        await s2.getAddress(),
+        await s3.getAddress(),
+        ],
+        // specific seed array
+        [10, 5, 1]
+      );
+      expect(await minterContract.ownerOf(1)).to.equal(await s1.getAddress());
+      expect(await minterContract.ownerOf(2)).to.equal(await s2.getAddress());
+      expect(await minterContract.ownerOf(3)).to.equal(await s3.getAddress());
+
+      await minterContract.mintEditions([
+        await s1.getAddress(),
+        await s2.getAddress(),
+        await s3.getAddress(),
+        await s2.getAddress(),
+        await s3.getAddress(),
+        await s2.getAddress(),
+        await s3.getAddress(),
+      ],
+      [2,4,3,9,8,7,6]);
+
+      await expect(minterContract.mintEditions([signerAddress],[11)).to.be.reverted;
+    });
+  });
+});

--- a/test/mint-with-seed.ts
+++ b/test/mint-with-seed.ts
@@ -129,7 +129,7 @@ describe.only("mint with seed feature", () => {
       const metadata1 = await fetchMetadata(1, minterContract)
 
       expect(
-        JSON.stringify(metadata1.animation_url)
+        metadata1.animation_url
       ).to.equal(
         "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=1"
         + `&address=${minterContract.address.toLowerCase()}`
@@ -148,7 +148,7 @@ describe.only("mint with seed feature", () => {
       const metadata2 = await fetchMetadata(2, minterContract)
 
       expect(
-        JSON.stringify(metadata2.animation_url)
+        metadata2.animation_url
       ).to.equal(
         "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=2"
         + `&address=${minterContract.address.toLowerCase()}`
@@ -168,7 +168,7 @@ describe.only("mint with seed feature", () => {
       const metadata3 = await fetchMetadata(3, minterContract)
 
       expect(
-        JSON.stringify(metadata3.animation_url)
+        metadata3.animation_url
       ).to.equal(
         "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=3"
         + `&address=${minterContract.address.toLowerCase()}`

--- a/test/mint-with-seed.ts
+++ b/test/mint-with-seed.ts
@@ -225,6 +225,44 @@ describe.only("mint with seed feature", () => {
     });
   });
 
+  describe("# purchase", () => {
+    let minterContract: SingleEditionMintable;
+    let oneEth = ethers.utils.parseEther("1")
+
+    beforeEach(async () => {
+      await dynamicSketch.createEdition(
+        "Testing Token",
+        "TEST",
+        "This is a testing token for all",
+        defaultVersion(),
+        10,
+        10
+      );
+
+      const editionResult = await dynamicSketch.getEditionAtId(0);
+      minterContract = (await ethers.getContractAt(
+        "SingleEditionMintable",
+        editionResult
+      )) as SingleEditionMintable;
+
+      // set sale price to 1 ETH
+      await minterContract.setSalePrice(oneEth)
+    });
+
+    it("purchases new edition", async () => {
+      await expect(
+         minterContract["purchase()"]({value: oneEth})
+      ).to.emit(minterContract, "EditionSold")
+    });
+
+    it("purchases new edition with seed", async () => {
+      const seed = 2
+      await expect(
+        minterContract["purchase(uint256)"](seed, {value: oneEth})
+     ).to.emit(minterContract, "EditionSold")
+    });
+  })
+
   describe("gas optimisation", () => {
     let signer: SignerWithAddress;
     let signerAddress: string;

--- a/test/mint-with-seed.ts
+++ b/test/mint-with-seed.ts
@@ -93,7 +93,7 @@ describe.only("mint with seed feature", () => {
 
     it("creates a new edition", async () => {
       // Mint first edition
-      await expect(minterContract.mintEdition(signerAddress))
+      await expect(minterContract["mintEdition(address)"](signerAddress))
         .to.emit(minterContract, "Transfer")
         .withArgs(
           "0x0000000000000000000000000000000000000000",
@@ -104,7 +104,7 @@ describe.only("mint with seed feature", () => {
 
     it("creates new edition with seed", async () => {
       const seed = 5
-      await expect(minterContract.mintEdition(signerAddress, seed)
+      await expect(minterContract["mintEdition(address,uint256)"](signerAddress, seed)
       ).to.emit(minterContract, "Transfer")
         .withArgs(
           "0x0000000000000000000000000000000000000000",
@@ -118,7 +118,7 @@ describe.only("mint with seed feature", () => {
       const seed = 2
 
       // with seed 2
-      await expect(minterContract.mintEdition(signerAddress, seed)
+      await expect(minterContract["mintEdition(address,uint256)"](signerAddress, seed)
       ).to.emit(minterContract, "Transfer")
         .withArgs(
           "0x0000000000000000000000000000000000000000",
@@ -137,7 +137,7 @@ describe.only("mint with seed feature", () => {
       );
 
       // without seed - seed = 1
-      await expect(minterContract.mintEdition(signerAddress)
+      await expect(minterContract["mintEdition(address)"](signerAddress)
       ).to.emit(minterContract, "Transfer")
         .withArgs(
           "0x0000000000000000000000000000000000000000",
@@ -157,7 +157,7 @@ describe.only("mint with seed feature", () => {
 
       // without seed - seed = 3
       // seed should skip 2 becuase already used
-      await expect(minterContract.mintEdition(signerAddress)
+      await expect(minterContract["mintEdition(address)"](signerAddress)
       ).to.emit(minterContract, "Transfer")
         .withArgs(
           "0x0000000000000000000000000000000000000000",
@@ -178,7 +178,7 @@ describe.only("mint with seed feature", () => {
 
     it("reverts if seed already used", async () => {
       // Mint first edition - seed = 1
-      await expect(minterContract.mintEdition(signerAddress))
+      await expect(minterContract["mintEdition(address)"](signerAddress))
         .to.emit(minterContract, "Transfer")
         .withArgs(
           "0x0000000000000000000000000000000000000000",
@@ -186,23 +186,23 @@ describe.only("mint with seed feature", () => {
           1
         );
 
-      await expect(minterContract.mintEdition(signerAddress, 1)
+      await expect(minterContract["mintEdition(address,uint256)"](signerAddress, 1)
       ).to.be.revertedWith("Seed already used")
     });
 
     it("reverts if seed out of range", async () => {
       await expect(
-         minterContract.mintEdition(signerAddress, 0)
+         minterContract["mintEdition(address,uint256)"](signerAddress, 0)
       ).to.be.revertedWith("Edition id out of range")
 
       await expect(
-         minterContract.mintEdition(signerAddress, 11)
+         minterContract["mintEdition(address,uint256)"](signerAddress, 11)
       ).to.be.revertedWith("Edition id out of range")
     });
 
     it("creates a set of editions with specific seeds", async () => {
       const [s1, s2, s3] = await ethers.getSigners();
-      await minterContract.mintEditions(
+      await minterContract["mintEditions(address[],uint256[])"](
         [
         await s1.getAddress(),
         await s2.getAddress(),
@@ -215,7 +215,7 @@ describe.only("mint with seed feature", () => {
       expect(await minterContract.ownerOf(2)).to.equal(await s2.getAddress());
       expect(await minterContract.ownerOf(3)).to.equal(await s3.getAddress());
 
-      await minterContract.mintEditions([
+      await minterContract["mintEditions(address[],uint256[])"]([
         await s1.getAddress(),
         await s2.getAddress(),
         await s3.getAddress(),
@@ -226,7 +226,7 @@ describe.only("mint with seed feature", () => {
       ],
       [2,4,3,9,8,7,6]);
 
-      await expect(minterContract.mintEditions([signerAddress],[11)).to.be.reverted;
+      await expect(minterContract["mintEditions(address[],uint256[])"]([signerAddress],[11])).to.be.reverted;
     });
   });
 });

--- a/test/mint-with-seed.ts
+++ b/test/mint-with-seed.ts
@@ -193,11 +193,11 @@ describe.only("mint with seed feature", () => {
     it("reverts if seed out of range", async () => {
       await expect(
          minterContract["mintEdition(address,uint256)"](signerAddress, 0)
-      ).to.be.revertedWith("Edition id out of range")
+      ).to.be.revertedWith("Seed out of range")
 
       await expect(
          minterContract["mintEdition(address,uint256)"](signerAddress, 11)
-      ).to.be.revertedWith("Edition id out of range")
+      ).to.be.revertedWith("Seed out of range")
     });
 
     it("creates a set of editions with specific seeds", async () => {


### PR DESCRIPTION
implementation of solution B from #3 

Each time a NFT is minted a seed is allocated to that nft. either by being specified or automatically by the contract.
A seed is a uint256 number within the range of 1 and edition size/max uint256

### Todo's
- [x] add to purchase function
- [x] refactor contract code
- [x] decided if thumbnails should be based on seed rather than Id
- [x] refactor tests
- [ ] mitigate out of gas vulnerabilities with unlimited editions*
- [ ] discuss further gas optimizations for auto seed allocation
- [ ] emit allocated seed in events to be able to track on the graph
- [ ] docs

* It is possible with unlimited/large editions that someone buys a large batch of seeds in sequence so that the contract is unable to auto allocate the next seed before gas limit is reached. Right now this can be mitigated by simply specifying the seed. But might need to be aware of this as a potential vulnerability to shut down an auction contract.