### PR TITLE
Separate contracts for editions and seeded editions

### DIFF
--- a/contracts/ISeededEditionSingleMintable.sol
+++ b/contracts/ISeededEditionSingleMintable.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.6;
+
+struct MintData {
+  address to;
+  uint256 seed;
+}
+
+interface ISeededEditionSingleMintable {
+  function mintEdition(address to, uint256 seed) external returns (uint256);
+  function mintEditions(MintData[] memory to) external returns (uint256);
+  function numberCanMint() external view returns (uint256);
+  function owner() external view returns (address);
+}

--- a/contracts/SeededSingleEditionMintable.sol
+++ b/contracts/SeededSingleEditionMintable.sol
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/**
+
+█▄░█ █▀▀ ▀█▀   █▀ █▀▀ █▀▀ █▀▄ █▀▀ █▀▄   █▀▀ █▀▄ █ ▀█▀ █ █▀█ █▄░█ █▀
+█░▀█ █▀░ ░█░   ▄█ ██▄ ██▄ █▄▀ ██▄ █▄▀   ██▄ █▄▀ █ ░█░ █ █▄█ █░▀█ ▄█
+
+▀█ █▀█ █▀█ ▄▀█   ▀▄▀   █▀█ █  ▀█▀ ▄▀█
+█▄ █▄█ █▀▄ █▀█   █░█   █▄█ █▄ ░█░ █▀█
+
+ */
+
+pragma solidity ^0.8.6;
+
+import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import {IERC2981Upgradeable, IERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {CountersUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
+import {AddressUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+
+import {SharedNFTLogic, MediaData} from "./SharedNFTLogic.sol";
+import {ISeededEditionSingleMintable, MintData} from "./ISeededEditionSingleMintable.sol";
+import {Versions} from "./Versions.sol";
+
+/**
+    This is a smart contract for handling dynamic contract minting.
+
+    This is a fork of Zora NFT Editions
+    changes:
+        - Media urls are versioned allowing for updatable content preserving history
+        - The NFT contract address is included in edition url query for easyier access to query the graph from within the NFT
+        - SupportsInterface function includes IEditionSingleMintable
+
+    @dev This allows creators to mint a unique serial edition of the same media within a custom contract
+    @author iain nash
+    Repository: https://github.com/ourzora/nft-editions
+*/
+contract SeededSingleEditionMintable is
+    ERC721Upgradeable,
+    ISeededEditionSingleMintable,
+    IERC2981Upgradeable,
+    OwnableUpgradeable
+{
+    using CountersUpgradeable for CountersUpgradeable.Counter;
+    using Versions for Versions.Set;
+    event PriceChanged(uint256 amount);
+    event EditionSold(uint256 price, address owner);
+    event VersionURLUpdated(uint8[3] label, uint8 index, string url);
+    event VersionAdded(uint8[3] label);
+    event ApprovedMinter(address indexed owner, address indexed minter, bool approved);
+
+    // metadata
+    string public description;
+
+    // Media Urls
+    // animation_url and image_url metadata
+    // TODO: swap these around and test they match
+    enum URLS  {
+        Image,
+        Animation
+    }
+    // Versions of Media Urls
+    Versions.Set private versions;
+
+    // Total size of edition that can be minted
+    uint256 public editionSize;
+    // Current token id minted
+    CountersUpgradeable.Counter private atEditionId;
+    // Royalty amount in bps
+    uint256 public royaltyBPS;
+    // Addresses allowed to mint edition
+    mapping(address => bool) allowedMinters;
+
+    // Mapping from seed to bool
+    mapping(uint256 => bool) seedsUsed;
+    // Mapping from tokenId to seed
+    mapping(uint256 => uint256) seedOfTokens;
+    // the last used seed closest to zero
+    uint256 private _lastUsedSeed;
+
+    // Price for sale
+    uint256 public salePrice;
+
+    // NFT rendering logic contract
+    SharedNFTLogic private immutable sharedNFTLogic;
+
+    // Global constructor for factory
+    constructor(SharedNFTLogic _sharedNFTLogic) {
+        sharedNFTLogic = _sharedNFTLogic;
+    }
+
+    /**
+      @param _owner User that owns and can mint the edition, gets royalty and sales payouts and can update the base url if needed.
+      @param _name Name of edition, used in the title as "$NAME NUMBER/TOTAL"
+      @param _symbol Symbol of the new token contract
+      @param _description Description of edition, used in the description field of the NFT
+      @param _version Version of the media consisting of urls and hashes of animation and image content
+      @param _editionSize Number of editions that can be minted in total. If 0, unlimited editions can be minted.
+      @param _royaltyBPS BPS of the royalty set on the contract. Can be 0 for no royalty.
+      @dev Function to create a new edition. Can only be called by the allowed creator
+           Sets the only allowed minter to the address that creates/owns the edition.
+           This can be re-assigned or updated later
+     */
+    function initialize(
+        address _owner,
+        string memory _name,
+        string memory _symbol,
+        string memory _description,
+        Versions.Version memory _version,
+        uint256 _editionSize,
+        uint256 _royaltyBPS
+    ) public initializer {
+        __ERC721_init(_name, _symbol);
+        __Ownable_init();
+        // Set ownership to original sender of contract call
+        transferOwnership(_owner);
+        description = _description;
+        editionSize = _editionSize;
+        royaltyBPS = _royaltyBPS;
+        // Set edition id start to be 1 not 0
+        atEditionId.increment();
+
+        // Add first version
+        versions.addVersion(_version);
+        emit VersionAdded(_version.label);
+    }
+
+
+    /// @dev returns the number of minted tokens within the edition
+    function totalSupply() public view returns (uint256) {
+        return atEditionId.current() - 1;
+    }
+    /**
+        Simple eth-based sales function
+        More complex sales functions can be implemented through ISingleEditionMintable interface
+     */
+
+    /**
+      @dev This allows the user to purchase a edition edition
+           at the given price in the contract.
+     */
+    function purchase(uint256 seed) external payable returns (uint256) {
+        require(salePrice > 0, "Not for sale");
+        require(msg.value == salePrice, "Wrong price");
+        MintData[] memory toMint = new MintData[](1);
+        toMint[0] = MintData(msg.sender, seed);
+        emit EditionSold(salePrice, msg.sender);
+        return _mintEditions(toMint);
+    }
+
+    /**
+      @param _salePrice if sale price is 0 sale is stopped, otherwise that amount 
+                       of ETH is needed to start the sale.
+      @dev This sets a simple ETH sales price
+           Setting a sales price allows users to mint the edition until it sells out.
+           For more granular sales, use an external sales contract.
+     */
+    function setSalePrice(uint256 _salePrice) external onlyOwner {
+        salePrice = _salePrice;
+        emit PriceChanged(salePrice);
+    }
+
+    /**
+      @dev This withdraws ETH from the contract to the contract owner.
+     */
+    function withdraw() external onlyOwner {
+        // No need for gas limit to trusted address.
+        AddressUpgradeable.sendValue(payable(owner()), address(this).balance);
+    }
+
+    /**
+      @dev This helper function checks if the msg.sender is allowed to mint the
+            given edition id.
+     */
+    function _isAllowedToMint() internal view returns (bool) {
+        if (owner() == msg.sender) {
+            return true;
+        }
+        if (allowedMinters[address(0x0)]) {
+            return true;
+        }
+        return allowedMinters[msg.sender];
+    }
+
+    /**
+      @param to address to send the newly minted edition to
+      @dev This mints one edition to the given address by an allowed minter on the edition instance.
+     */
+    function mintEdition(address to, uint256 seed) external override returns (uint256) {
+        require(_isAllowedToMint(), "Needs to be an allowed minter");
+        MintData[] memory toMint = new MintData[](1);
+        toMint[0] = MintData(to, seed);
+        return _mintEditions(toMint);
+    }
+
+    /**
+      @param recipients list of addresses and seeds to send the newly minted editions to
+      @dev This mints multiple editions to the given list of addresses.
+     */
+    function mintEditions(MintData[] memory recipients)
+        external
+        override
+        returns (uint256)
+    {
+        require(_isAllowedToMint(), "Needs to be an allowed minter");
+        return _mintEditions(recipients);
+    }
+
+    /**
+        Simple override for owner interface.
+     */
+    function owner()
+        public
+        view
+        override(OwnableUpgradeable, ISeededEditionSingleMintable)
+        returns (address)
+    {
+        return super.owner();
+    }
+
+    /**
+      @param minter address to set approved minting status for
+      @param allowed boolean if that address is allowed to mint
+      @dev Sets the approved minting status of the given address.
+           This requires that msg.sender is the owner of the given edition id.
+           If the ZeroAddress (address(0x0)) is set as a minter,
+             anyone will be allowed to mint.
+           This setup is similar to setApprovalForAll in the ERC721 spec.
+     */
+    function setApprovedMinter(address minter, bool allowed) public onlyOwner {
+        allowedMinters[minter] = allowed;
+        emit ApprovedMinter(_msgSender(), minter, allowed);
+    }
+
+    /**
+      @dev Updates a url of specified version by the owner of the edition.
+           Only URLs can be updated (data-uris are supported), hashes cannot be updated.
+      @param _label The label of the specified version
+      @param _urlKey The index of the url to update 0=animation, 1=image
+      @param _url The url to be updated to
+     */
+    function updateVersionURL(
+        uint8[3] memory _label,
+        uint8 _urlKey,
+        string memory _url
+    ) public onlyOwner {
+        versions.updateVersionURL(_label, _urlKey, _url);
+        emit VersionURLUpdated(_label, _urlKey, _url);
+    }
+
+    /**
+      @dev Adds new version of the media updating the urls rendered in the metadata.
+           The order added determins order stored, the label has no effect.
+      @param _version The version to be added consisting of urls, hashes and a label
+     */
+    function addVersion(
+        Versions.Version memory _version
+    ) public onlyOwner {
+        versions.addVersion(_version);
+        emit VersionAdded(_version.label);
+    }
+
+    function getVersionHistory()
+        public
+        view
+        returns (Versions.Version[] memory)
+    {
+        return versions.getAllVersions();
+    }
+
+    /// Returns the number of editions allowed to mint (max_uint256 when open edition)
+    function numberCanMint() public view override returns (uint256) {
+        // Return max int if open edition
+        if (editionSize == 0) {
+            return type(uint256).max;
+        }
+        // atEditionId is one-indexed hence the need to remove one here
+        return editionSize + 1 - atEditionId.current();
+    }
+
+    /**
+        @param tokenId Token ID to burn
+        User burn function for token id
+     */
+    function burn(uint256 tokenId) public {
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "Not approved");
+        _burn(tokenId);
+    }
+
+    /**
+        @param seed uint256 of the seed
+        @dev  checks to see if seed is in valid range
+    */
+    function _isSeedInRange(uint256 seed) private view returns (bool) {
+        return ((seed > 0) && (seed <= editionSize));
+    }
+
+    /**
+        @param tokenId Token ID for the seed to be allocated to
+        @param seed Seed to be used
+    */
+    function _useSeed(uint256 tokenId, uint256 seed) internal {
+        // check if seed has been used
+        require(seedsUsed[seed] == false, "Seed already used");
+        // check if seed is out of range
+        require(_isSeedInRange(seed), "Seed out of range");
+
+        // allocate seed to id
+        seedsUsed[seed] = true;
+        seedOfTokens[tokenId] = seed;
+    }
+
+    /**
+      @dev Private function to mint als without any access checks.
+           Called by the public edition minting functions.
+           allocates requested seeds
+     */
+    function _mintEditions(MintData[] memory recipients)
+        internal
+        returns (uint256)
+    {
+        uint256 startAt = atEditionId.current();
+        uint256 endAt = startAt + recipients.length - 1;
+        require(editionSize == 0 || endAt <= editionSize, "Sold out");
+
+        while (atEditionId.current() <= endAt) {
+            _useSeed(
+                atEditionId.current(),
+                recipients[atEditionId.current() - startAt].seed
+            );
+
+            _mint(
+                recipients[atEditionId.current() - startAt].to,
+                atEditionId.current()
+            );
+            atEditionId.increment();
+        }
+        return atEditionId.current();
+    }
+
+    /**
+      @dev Get URIs for edition NFT
+            Will get URIs from the last version added
+      @return imageUrl, imageHash, animationUrl, animationHash
+     */
+    function getURIs()
+        public
+        view
+        returns (
+            string memory,
+            bytes32,
+            string memory,
+            bytes32
+        )
+    {
+        Versions.Version memory latest = versions.getLatestVersion();
+        return (
+            latest.urls[uint8(URLS.Image)].url,
+            latest.urls[uint8(URLS.Image)].sha256hash,
+            latest.urls[uint8(URLS.Animation)].url,
+            latest.urls[uint8(URLS.Animation)].sha256hash
+        );
+    }
+
+    /**
+      @dev Get URIs for edition NFT of a version
+           Will get URIs from the last version added
+      @param label The label of the version
+      @return imageUrl, imageHash, animationUrl, animationHash
+     */
+    function getURIsOfVersion(
+        uint8[3] memory label
+    )
+        public
+        view
+        returns (
+            string memory,
+            bytes32,
+            string memory,
+            bytes32
+        )
+    {
+        Versions.Version memory version = versions.getVersion(label);
+        return (
+            version.urls[uint8(URLS.Image)].url,
+            version.urls[uint8(URLS.Image)].sha256hash,
+            version.urls[uint8(URLS.Animation)].url,
+            version.urls[uint8(URLS.Animation)].sha256hash
+        );
+    }
+
+    /**
+        @dev Get royalty information for token
+        @param _salePrice Sale price for the token
+     */
+    function royaltyInfo(uint256, uint256 _salePrice)
+        external
+        view
+        override
+        returns (address receiver, uint256 royaltyAmount)
+    {
+        if (owner() == address(0x0)) {
+            return (owner(), 0);
+        }
+        return (owner(), (_salePrice * royaltyBPS) / 10_000);
+    }
+
+    /**
+        @dev Get URI for given token id
+             Will get URIs from the last version added
+        @param tokenId token id to get uri for
+        @return base64-encoded json metadata object
+    */
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        require(_exists(tokenId), "No token");
+        Versions.Version memory version = versions.getLatestVersion();
+        return
+            sharedNFTLogic.createMetadataEdition(
+                name(),
+                description,
+                MediaData(
+                    version.urls[uint8(URLS.Image)].url,
+                    version.urls[uint8(URLS.Animation)].url,
+                    version.label
+                ),
+                tokenId,
+                editionSize,
+                address(this),
+                seedOfTokens[tokenId]
+            );
+    }
+
+    /**
+        @dev Get URI for given token id of version
+        @param tokenId token id to get uri for
+        @param label the label of the version
+        @return base64-encoded json metadata object
+    */
+    function tokenURIOfVersion(
+        uint256 tokenId,
+        uint8[3] memory label
+    )
+        public
+        view
+        returns (string memory)
+    {
+        require(_exists(tokenId), "No token");
+        Versions.Version memory version = versions.getVersion(label);
+
+        return
+            sharedNFTLogic.createMetadataEdition(
+                name(),
+                description,
+                MediaData(
+                    version.urls[uint8(URLS.Image)].url,
+                    version.urls[uint8(URLS.Animation)].url,
+                    version.label
+                ),
+                tokenId,
+                editionSize,
+                address(this),
+                seedOfTokens[tokenId]
+            );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721Upgradeable, IERC165Upgradeable)
+        returns (bool)
+    {
+        return
+            type(ISeededEditionSingleMintable).interfaceId == interfaceId ||
+            type(IERC2981Upgradeable).interfaceId == interfaceId ||
+            ERC721Upgradeable.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/SeededSingleEditionMintable.sol
+++ b/contracts/SeededSingleEditionMintable.sol
@@ -53,8 +53,6 @@ contract SeededSingleEditionMintable is
     string public description;
 
     // Media Urls
-    // animation_url and image_url metadata
-    // TODO: swap these around and test they match
     enum URLS  {
         Image,
         Animation
@@ -72,11 +70,9 @@ contract SeededSingleEditionMintable is
     mapping(address => bool) allowedMinters;
 
     // Mapping from seed to bool
-    mapping(uint256 => bool) seedsUsed;
+    mapping(uint256 => bool) public seedsUsed;
     // Mapping from tokenId to seed
-    mapping(uint256 => uint256) seedOfTokens;
-    // the last used seed closest to zero
-    uint256 private _lastUsedSeed;
+    mapping(uint256 => uint256) public seedOfTokens;
 
     // Price for sale
     uint256 public salePrice;

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -92,6 +92,39 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         return encodeMetadataJSON(json);
     }
 
+    /// Generate edition metadata from storage information as base64-json blob
+    /// Combines the media data and metadata
+    /// @param name Name of NFT in metadata
+    /// @param description Description of NFT in metadata
+    /// @param media The image Url, animation Url and version label of the media to be rendered
+    /// @param tokenOfEdition Token ID for specific token
+    /// @param editionSize Size of entire edition to show
+    /// @param tokenAddress Address of the NFT
+    function createMetadataEdition(
+        string memory name,
+        string memory description,
+        MediaData memory media,
+        uint256 tokenOfEdition,
+        uint256 editionSize,
+        address tokenAddress,
+        uint256 tokenSeed
+    ) external pure returns (string memory) {
+        string memory _tokenMediaData = tokenMediaData(
+            media,
+            tokenOfEdition,
+            tokenAddress,
+            tokenSeed
+        );
+        bytes memory json = createMetadataJSON(
+            name,
+            description,
+            _tokenMediaData,
+            tokenOfEdition,
+            editionSize
+        );
+        return encodeMetadataJSON(json);
+    }
+
     /// Function to create the metadata json string for the nft edition
     /// @param name Name of NFT in metadata
     /// @param description Description of NFT in metadata
@@ -205,6 +238,78 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                         numberToString(tokenOfEdition),
                         "&address=",
                         addressToString(tokenAddress),
+                        '", "',
+                        'media_version": "',
+                        uintArray3ToString(media.label),
+                        '", "'
+                    )
+                );
+        }
+
+        return "";
+    }
+
+    /// Generates edition metadata from storage information as base64-json blob
+    /// Combines the media data and metadata
+    /// @param media urls of image and animation media with version label
+    function tokenMediaData(
+        MediaData memory media,
+        uint256 tokenOfEdition,
+        address tokenAddress,
+        uint256 tokenSeed
+    ) public pure returns (string memory) {
+        bool hasImage = bytes(media.imageUrl).length > 0;
+        bool hasAnimation = bytes(media.animationUrl).length > 0;
+        if (hasImage && hasAnimation) {
+            return
+                string(
+                    abi.encodePacked(
+                        'image": "',
+                        media.imageUrl,
+                        "?seed=",
+                        numberToString(tokenSeed),
+                        '", "animation_url": "',
+                        media.animationUrl,
+                        "?id=",
+                        numberToString(tokenOfEdition),
+                        "&address=",
+                        addressToString(tokenAddress),
+                        "&seed=",
+                        numberToString(tokenSeed),
+                        '", "',
+                        'media_version": "',
+                        uintArray3ToString(media.label),
+                        '", "'
+                    )
+                );
+        }
+        if (hasImage) {
+            return
+                string(
+                    abi.encodePacked(
+                        'image": "',
+                        media.imageUrl,
+                        "?seed=", // if just url "/id" this will work with arweave pathmanifests
+                        numberToString(tokenSeed),
+                        '", "',
+                        'media_version": "',
+                        uintArray3ToString(media.label),
+                        '", "'
+                    )
+                );
+        }
+        if (hasAnimation) {
+            return
+                string(
+                    abi.encodePacked(
+                        'animation_url": "',
+                        media.animationUrl,
+                        "?id=",
+                        numberToString(tokenOfEdition),
+                        "&address=",
+                        addressToString(tokenAddress),
+                        "&seed=",
+                        numberToString(tokenSeed),
                         '", "',
                         'media_version": "',
                         uintArray3ToString(media.label),

--- a/contracts/SingleEditionMintableCreator.sol
+++ b/contracts/SingleEditionMintableCreator.sol
@@ -47,7 +47,7 @@ contract SingleEditionMintableCreator {
     /// @param _implementations Array of addresse for implementations of SingleEditionMintable like contracts to clone
     constructor(address[] memory _implementations) {
         implementations[uint8(Implementation.editions)] = _implementations[uint8(Implementation.editions)];
-        implementations[uint8(Implementation.seededEditions)] = _implementations[uint8(Implementation.editions)];
+        implementations[uint8(Implementation.seededEditions)] = _implementations[uint8(Implementation.seededEditions)];
     }
 
     /// Creates a new edition contract as a factory with a deterministic address

--- a/contracts/SingleEditionMintableCreator.sol
+++ b/contracts/SingleEditionMintableCreator.sol
@@ -26,6 +26,17 @@ contract SingleEditionMintableCreator {
         seededEditions
     }
 
+    /// Important: None of these fields can be changed after calling
+    /// urls can be updated and upgraded via the versions interface
+    struct EditionData {
+        string name; // Name of the edition contract
+        string symbol; // Symbol of the edition contract
+        string description; /// Metadata: Description of the edition entry
+        Versions.Version version; /// Version media with animation url, animation sha256hash, image url, image sha256hash
+        uint256 editionSize; /// Total size of the edition (number of possible editions)
+        uint256 royaltyBPS; /// BPS amount of royalty
+    }
+
     /// Counter for current contract id upgraded
     CountersUpgradeable.Counter[2] private atContracts;
 
@@ -33,65 +44,72 @@ contract SingleEditionMintableCreator {
     address[2] public implementations;
 
     /// Initializes factory with address of implementations logic
-    /// @param _editionsImplementation SingleEditionMintable logic implementation contract to clone
-    /// @param _seededEditionsImplementation SeededSingleEditionMintable logic implementation contract to clone
-    constructor(address _editionsImplementation, address _seededEditionsImplementation) {
-        implementations[uint8(Implementation.editions)] = _editionsImplementation;
-        implementations[uint8(Implementation.seededEditions)] = _seededEditionsImplementation;
+    /// @param _implementations Array of addresse for implementations of SingleEditionMintable like contracts to clone
+    constructor(address[] memory _implementations) {
+        implementations[uint8(Implementation.editions)] = _implementations[uint8(Implementation.editions)];
+        implementations[uint8(Implementation.seededEditions)] = _implementations[uint8(Implementation.editions)];
     }
 
     /// Creates a new edition contract as a factory with a deterministic address
-    /// Important: None of these fields (except the Url fields with the same hash) can be changed after calling
-    /// @param _name Name of the edition contract
-    /// @param _symbol Symbol of the edition contract
-    /// @param _description Metadata: Description of the edition entry
-    /// @param _version Version media with animation url, animation sha256hash, image url, image sha256hash
-    /// @param _editionSize Total size of the edition (number of possible editions)
-    /// @param _royaltyBPS BPS amount of royalty
+    /// @param editionData EditionData of the edition contract
+    /// @param implementation Implementation of the edition contract
+
     function createEdition(
-        string memory _name,
-        string memory _symbol,
-        string memory _description,
-        Versions.Version memory _version,
-        uint256 _editionSize,
-        uint256 _royaltyBPS
+        EditionData memory editionData,
+        uint8 implementation
     ) external returns (uint256) {
-        uint256 newId = atContracts[uint8(Implementation.editions)].current();
+        uint256 newId = atContracts[implementation].current();
         address newContract = ClonesUpgradeable.cloneDeterministic(
-            implementations[uint8(Implementation.editions)],
+            implementations[implementation],
             bytes32(abi.encodePacked(newId))
         );
-        SingleEditionMintable(newContract).initialize(
-            msg.sender,
-            _name,
-            _symbol,
-            _description,
-            _version,
-            _editionSize,
-            _royaltyBPS
-        );
-        emit CreatedEdition(newId, msg.sender, _editionSize, newContract);
+
+        // Editions
+        if (implementation == uint8(Implementation.editions)){
+            SingleEditionMintable(newContract).initialize(
+                msg.sender,
+                editionData.name,
+                editionData.symbol,
+                editionData.description,
+                editionData.version,
+                editionData.editionSize,
+                editionData.royaltyBPS
+            );
+        }
+
+        // Seeded Editions
+        if (implementation == uint8(Implementation.seededEditions)){
+            SeededSingleEditionMintable(newContract).initialize(
+                msg.sender,
+                editionData.name,
+                editionData.symbol,
+                editionData.description,
+                editionData.version,
+                editionData.editionSize,
+                editionData.royaltyBPS
+            );
+        }
+
+        emit CreatedEdition(newId, msg.sender, editionData.editionSize, newContract, implementation);
         // Returns the ID of the recently created minting contract
         // Also increments for the next contract creation call
-        atContracts[uint8(Implementation.editions)].increment();
+        atContracts[implementation].increment();
         return newId;
     }
 
     /// Get edition given the created ID
     /// @param editionId id of edition to get contract for
     /// @return SingleEditionMintable Edition NFT contract
-    function getEditionAtId(uint256 editionId)
+    function getEditionAtId(uint256 editionId, uint8 implementation)
         external
         view
-        returns (SingleEditionMintable)
+        returns (address)
     {
         return
-            SingleEditionMintable(
-                ClonesUpgradeable.predictDeterministicAddress(
-                    implementations[uint8(Implementation.editions)],
-                    bytes32(abi.encodePacked(editionId)),
-                    address(this)
-                )
+            ClonesUpgradeable.predictDeterministicAddress(
+                implementations[implementation],
+                bytes32(abi.encodePacked(editionId)),
+                address(this)
             );
     }
 
@@ -101,70 +119,7 @@ contract SingleEditionMintableCreator {
         uint256 indexed editionId,
         address indexed creator,
         uint256 editionSize,
-        address editionContractAddress
-    );
-
-     /// Creates a new edition contract as a factory with a deterministic address
-    /// Important: None of these fields (except the Url fields with the same hash) can be changed after calling
-    /// @param _name Name of the edition contract
-    /// @param _symbol Symbol of the edition contract
-    /// @param _description Metadata: Description of the edition entry
-    /// @param _version Version media with animation url, animation sha256hash, image url, image sha256hash
-    /// @param _editionSize Total size of the edition (number of possible editions)
-    /// @param _royaltyBPS BPS amount of royalty
-    function createSeededEdition(
-        string memory _name,
-        string memory _symbol,
-        string memory _description,
-        Versions.Version memory _version,
-        uint256 _editionSize,
-        uint256 _royaltyBPS
-    ) external returns (uint256) {
-        uint256 newId = atContracts[uint8(Implementation.seededEditions)].current();
-        address newContract = ClonesUpgradeable.cloneDeterministic(
-            implementations[uint8(Implementation.seededEditions)],
-            bytes32(abi.encodePacked(newId))
-        );
-        SeededSingleEditionMintable(newContract).initialize(
-            msg.sender,
-            _name,
-            _symbol,
-            _description,
-            _version,
-            _editionSize,
-            _royaltyBPS
-        );
-        emit CreatedSeededEdition(newId, msg.sender, _editionSize, newContract);
-        // Returns the ID of the recently created minting contract
-        // Also increments for the next contract creation call
-        atContracts[uint8(Implementation.seededEditions)].increment();
-        return newId;
-    }
-
-    /// Get edition given the created ID
-    /// @param editionId id of edition to get contract for
-    /// @return SeededSingleEditionMintable Edition NFT contract
-    function getSeededEditionAtId(uint256 editionId)
-        external
-        view
-        returns (SeededSingleEditionMintable)
-    {
-        return
-            SeededSingleEditionMintable(
-                ClonesUpgradeable.predictDeterministicAddress(
-                    implementations[uint8(Implementation.seededEditions)],
-                    bytes32(abi.encodePacked(editionId)),
-                    address(this)
-                )
-            );
-    }
-
-    /// Emitted when a edition is created reserving the corresponding token IDs.
-    /// @param editionId ID of newly created edition
-    event CreatedSeededEdition(
-        uint256 indexed editionId,
-        address indexed creator,
-        uint256 editionSize,
-        address editionContractAddress
+        address editionContractAddress,
+        uint8 implementation
     );
 }

--- a/contracts/SingleEditionMintableCreator.sol
+++ b/contracts/SingleEditionMintableCreator.sol
@@ -16,20 +16,28 @@ import {ClonesUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/Clone
 import {CountersUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import {Versions} from "./Versions.sol";
 import "./SingleEditionMintable.sol";
+import "./SeededSingleEditionMintable.sol";
 
 contract SingleEditionMintableCreator {
     using CountersUpgradeable for CountersUpgradeable.Counter;
 
+    enum Implementation {
+        editions,
+        seededEditions
+    }
+
     /// Counter for current contract id upgraded
-    CountersUpgradeable.Counter private atContract;
+    CountersUpgradeable.Counter[2] private atContracts;
 
     /// Address for implementation of SingleEditionMintable to clone
-    address public implementation;
+    address[2] public implementations;
 
-    /// Initializes factory with address of implementation logic
-    /// @param _implementation SingleEditionMintable logic implementation contract to clone
-    constructor(address _implementation) {
-        implementation = _implementation;
+    /// Initializes factory with address of implementations logic
+    /// @param _editionsImplementation SingleEditionMintable logic implementation contract to clone
+    /// @param _seededEditionsImplementation SeededSingleEditionMintable logic implementation contract to clone
+    constructor(address _editionsImplementation, address _seededEditionsImplementation) {
+        implementations[uint8(Implementation.editions)] = _editionsImplementation;
+        implementations[uint8(Implementation.seededEditions)] = _seededEditionsImplementation;
     }
 
     /// Creates a new edition contract as a factory with a deterministic address
@@ -48,9 +56,9 @@ contract SingleEditionMintableCreator {
         uint256 _editionSize,
         uint256 _royaltyBPS
     ) external returns (uint256) {
-        uint256 newId = atContract.current();
+        uint256 newId = atContracts[uint8(Implementation.editions)].current();
         address newContract = ClonesUpgradeable.cloneDeterministic(
-            implementation,
+            implementations[uint8(Implementation.editions)],
             bytes32(abi.encodePacked(newId))
         );
         SingleEditionMintable(newContract).initialize(
@@ -65,7 +73,7 @@ contract SingleEditionMintableCreator {
         emit CreatedEdition(newId, msg.sender, _editionSize, newContract);
         // Returns the ID of the recently created minting contract
         // Also increments for the next contract creation call
-        atContract.increment();
+        atContracts[uint8(Implementation.editions)].increment();
         return newId;
     }
 
@@ -80,7 +88,7 @@ contract SingleEditionMintableCreator {
         return
             SingleEditionMintable(
                 ClonesUpgradeable.predictDeterministicAddress(
-                    implementation,
+                    implementations[uint8(Implementation.editions)],
                     bytes32(abi.encodePacked(editionId)),
                     address(this)
                 )
@@ -90,6 +98,70 @@ contract SingleEditionMintableCreator {
     /// Emitted when a edition is created reserving the corresponding token IDs.
     /// @param editionId ID of newly created edition
     event CreatedEdition(
+        uint256 indexed editionId,
+        address indexed creator,
+        uint256 editionSize,
+        address editionContractAddress
+    );
+
+     /// Creates a new edition contract as a factory with a deterministic address
+    /// Important: None of these fields (except the Url fields with the same hash) can be changed after calling
+    /// @param _name Name of the edition contract
+    /// @param _symbol Symbol of the edition contract
+    /// @param _description Metadata: Description of the edition entry
+    /// @param _version Version media with animation url, animation sha256hash, image url, image sha256hash
+    /// @param _editionSize Total size of the edition (number of possible editions)
+    /// @param _royaltyBPS BPS amount of royalty
+    function createSeededEdition(
+        string memory _name,
+        string memory _symbol,
+        string memory _description,
+        Versions.Version memory _version,
+        uint256 _editionSize,
+        uint256 _royaltyBPS
+    ) external returns (uint256) {
+        uint256 newId = atContracts[uint8(Implementation.seededEditions)].current();
+        address newContract = ClonesUpgradeable.cloneDeterministic(
+            implementations[uint8(Implementation.seededEditions)],
+            bytes32(abi.encodePacked(newId))
+        );
+        SeededSingleEditionMintable(newContract).initialize(
+            msg.sender,
+            _name,
+            _symbol,
+            _description,
+            _version,
+            _editionSize,
+            _royaltyBPS
+        );
+        emit CreatedSeededEdition(newId, msg.sender, _editionSize, newContract);
+        // Returns the ID of the recently created minting contract
+        // Also increments for the next contract creation call
+        atContracts[uint8(Implementation.seededEditions)].increment();
+        return newId;
+    }
+
+    /// Get edition given the created ID
+    /// @param editionId id of edition to get contract for
+    /// @return SeededSingleEditionMintable Edition NFT contract
+    function getSeededEditionAtId(uint256 editionId)
+        external
+        view
+        returns (SeededSingleEditionMintable)
+    {
+        return
+            SeededSingleEditionMintable(
+                ClonesUpgradeable.predictDeterministicAddress(
+                    implementations[uint8(Implementation.seededEditions)],
+                    bytes32(abi.encodePacked(editionId)),
+                    address(this)
+                )
+            );
+    }
+
+    /// Emitted when a edition is created reserving the corresponding token IDs.
+    /// @param editionId ID of newly created edition
+    event CreatedSeededEdition(
         uint256 indexed editionId,
         address indexed creator,
         uint256 editionSize,

--- a/deploy/04_seededsingleeditionmintable.ts
+++ b/deploy/04_seededsingleeditionmintable.ts
@@ -1,0 +1,16 @@
+module.exports = async ({ getNamedAccounts, deployments }: any) => {
+  const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+
+  const sharedNFTLogicAddress = (await deployments.get("SharedNFTLogic")).address;
+
+  await deploy("SeededSingleEditionMintable", {
+    from: deployer,
+    args: [
+      sharedNFTLogicAddress
+    ],
+    log: true,
+  });
+};
+module.exports.tags = ["SeededSingleEditionMintable"];
+module.exports.dependencies = ["SharedNFTLogic"]

--- a/deploy/05_singleeditionmintablecreator.ts
+++ b/deploy/05_singleeditionmintablecreator.ts
@@ -3,12 +3,13 @@ module.exports = async ({ getNamedAccounts, deployments }: any) => {
   const { deployer } = await getNamedAccounts();
 
   const mintableAddress = (await deployments.get("SingleEditionMintable")).address;
+  const seededMintableAddress = (await deployments.get("SeededSingleEditionMintable")).address;
 
   await deploy("SingleEditionMintableCreator", {
     from: deployer,
-    args: [mintableAddress],
+    args: [mintableAddress, seededMintableAddress],
     log: true,
   });
 };
 module.exports.tags = ["SingleEditionMintableCreator"];
-module.exports.dependencies = ["SingleEditionMintable"];
+module.exports.dependencies = ["SingleEditionMintable", "SeededSingleEditionMintable"];

--- a/deploy/05_singleeditionmintablecreator.ts
+++ b/deploy/05_singleeditionmintablecreator.ts
@@ -7,7 +7,7 @@ module.exports = async ({ getNamedAccounts, deployments }: any) => {
 
   await deploy("SingleEditionMintableCreator", {
     from: deployer,
-    args: [mintableAddress, seededMintableAddress],
+    args: [[mintableAddress, seededMintableAddress]],
     log: true,
   });
 };

--- a/test/SeededSingleEditionMintableTest.ts
+++ b/test/SeededSingleEditionMintableTest.ts
@@ -1,0 +1,222 @@
+// Note[George]: Quickly copied over relevant tests to check feature change
+// to only run this test use `yarn hardhat test ./test/mint-with-seed.ts`
+
+import { expect } from "chai";
+import "@nomiclabs/hardhat-ethers";
+import { ethers, deployments } from "hardhat";
+import parseDataURI from "data-urls";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import {
+  SingleEditionMintableCreator,
+  SeededSingleEditionMintable,
+} from "../typechain";
+import { BigNumberish } from "ethers";
+
+type Label = [BigNumberish, BigNumberish, BigNumberish]
+
+const defaultAnimationURl = "https://arweave.net/<tx-hash-length-000000000000000000000>"
+
+const defaultVersion = () => {
+  return {
+    urls: [
+      // image
+      {
+        url: "",
+        sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+      },
+      // animation
+      {
+        url: defaultAnimationURl,
+        sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      },
+    ],
+    label: [0,0,1] as Label
+  }
+}
+
+// Helpers
+
+const fetchMetadata = async (tokenId: number, contract: SeededSingleEditionMintable) => {
+  const tokenURI = await contract.tokenURI(tokenId);
+  const parsedTokenURI = parseDataURI(tokenURI);
+  if (!parsedTokenURI) {
+    throw "No parsed token uri";
+  }
+
+  // parse metadata body
+  const uriData = Buffer.from(parsedTokenURI.body).toString("utf-8");
+  return JSON.parse(uriData);
+}
+
+const getAnimationUrl = async (contract: SeededSingleEditionMintable, id: number) => {
+  const metadata = await fetchMetadata(id, contract)
+  return metadata.animation_url
+}
+
+const expectedUrl = (contract: SeededSingleEditionMintable, id: number, seed: number) => {
+  return defaultAnimationURl
+    + "?"
+    + `id=${id}`
+    + `&address=${contract.address.toLowerCase()}`
+    + `&seed=${seed}`
+}
+
+const createMintData = (to: string, seed: number) => ({to, seed})
+
+describe("mint with seed feature", () => {
+  let signer: SignerWithAddress;
+  let signerAddress: string;
+  let dynamicSketch: SingleEditionMintableCreator;
+
+  beforeEach(async () => {
+    const { SingleEditionMintableCreator } = await deployments.fixture([
+      "SingleEditionMintableCreator",
+    ]);
+    const dynamicMintableAddress = (
+      await deployments.get("SeededSingleEditionMintable")
+    ).address;
+    dynamicSketch = (await ethers.getContractAt(
+      "SingleEditionMintableCreator",
+      SingleEditionMintableCreator.address
+    )) as SingleEditionMintableCreator;
+
+    signer = (await ethers.getSigners())[0];
+    signerAddress = await signer.getAddress();
+  });
+
+  describe("# mintEdition", () => {
+    let minterContract: SeededSingleEditionMintable;
+
+    beforeEach(async () => {
+      await dynamicSketch.createSeededEdition(
+        "Testing Token",
+        "TEST",
+        "This is a testing token for all",
+        defaultVersion(),
+        10,
+        10
+      );
+
+      const editionResult = await dynamicSketch.getSeededEditionAtId(0);
+      minterContract = (await ethers.getContractAt(
+        "SeededSingleEditionMintable",
+        editionResult
+      )) as SeededSingleEditionMintable;
+    });
+
+    it("creates new edition with seed", async () => {
+      const seed = 1
+      await expect(
+        minterContract.mintEdition(signerAddress, seed)
+      ).to.emit(minterContract, "Transfer")
+    });
+
+    it("reverts if seed already used", async () => {
+      const seed = 1
+      await expect(
+        minterContract.mintEdition(signerAddress, seed)
+      ).to.emit(minterContract, "Transfer")
+
+      await expect(
+        minterContract.mintEdition(signerAddress, seed)
+      ).to.be.revertedWith("Seed already used")
+    });
+
+    it("reverts if seed out of range", async () => {
+      await expect(
+         minterContract.mintEdition(signerAddress, 0)
+      ).to.be.revertedWith("Seed out of range")
+
+      await expect(
+         minterContract.mintEdition(signerAddress, 11)
+      ).to.be.revertedWith("Seed out of range")
+    });
+
+  });
+
+  describe("# mintEditions", () => {
+
+    let minterContract: SeededSingleEditionMintable;
+
+    beforeEach(async () => {
+      await dynamicSketch.createSeededEdition(
+        "Testing Token",
+        "TEST",
+        "This is a testing token for all",
+        defaultVersion(),
+        10,
+        10
+      );
+
+      const editionResult = await dynamicSketch.getSeededEditionAtId(0);
+      minterContract = (await ethers.getContractAt(
+        "SeededSingleEditionMintable",
+        editionResult
+      )) as SeededSingleEditionMintable;
+    });
+
+
+    it("creates a set of editions with specific seeds", async () => {
+      const [s1, s2, s3] = await ethers.getSigners();
+
+      await minterContract.mintEditions(
+        [
+          createMintData(await s1.getAddress(), 10),
+          createMintData(await s2.getAddress(), 5),
+          createMintData(await s3.getAddress(), 1),
+        ],
+      );
+      expect(await minterContract.ownerOf(1)).to.equal(await s1.getAddress());
+      expect(await minterContract.ownerOf(2)).to.equal(await s2.getAddress());
+      expect(await minterContract.ownerOf(3)).to.equal(await s3.getAddress());
+
+      await minterContract.mintEditions(
+        [
+          createMintData(await s1.getAddress(), 2),
+          createMintData(await s2.getAddress(), 4),
+          createMintData(await s3.getAddress(), 3),
+          createMintData(await s2.getAddress(), 9),
+          createMintData(await s3.getAddress(), 8),
+          createMintData(await s2.getAddress(), 7),
+          createMintData(await s3.getAddress(), 6),
+        ]
+      );
+
+      await expect(
+        minterContract.mintEditions([createMintData(signerAddress, 11)])
+      ).to.be.reverted;
+    });
+  });
+
+  describe("# purchase", () => {
+    let minterContract: SeededSingleEditionMintable;
+    let oneEth = ethers.utils.parseEther("1")
+
+    beforeEach(async () => {
+      await dynamicSketch.createSeededEdition(
+        "Testing Token",
+        "TEST",
+        "This is a testing token for all",
+        defaultVersion(),
+        10,
+        10
+      );
+
+      const editionResult = await dynamicSketch.getSeededEditionAtId(0);
+      minterContract = (await ethers.getContractAt(
+        "SeededSingleEditionMintable",
+        editionResult
+      )) as SeededSingleEditionMintable;
+
+      // set sale price to 1 ETH
+      await minterContract.setSalePrice(oneEth)
+    });
+
+    it("purchases new edition with seed", async () => {
+      const seed = 2
+      await expect(
+        minterContract.purchase(seed, {value: oneEth})
+     ).to.emit(minterContract, "EditionSold")
+    });
+  })
+});

--- a/test/SeededSingleEditionMintableTest.ts
+++ b/test/SeededSingleEditionMintableTest.ts
@@ -10,9 +10,12 @@ import {
   SingleEditionMintableCreator,
   SeededSingleEditionMintable,
 } from "../typechain";
-import { BigNumberish } from "ethers";
 
-type Label = [BigNumberish, BigNumberish, BigNumberish]
+import {
+  editionData,
+  Implementation,
+  Label
+} from "./utils"
 
 const defaultAnimationURl = "https://arweave.net/<tx-hash-length-000000000000000000000>"
 
@@ -63,7 +66,7 @@ const expectedUrl = (contract: SeededSingleEditionMintable, id: number, seed: nu
 
 const createMintData = (to: string, seed: number) => ({to, seed})
 
-describe("mint with seed feature", () => {
+describe.only("mint with seed feature", () => {
   let signer: SignerWithAddress;
   let signerAddress: string;
   let dynamicSketch: SingleEditionMintableCreator;
@@ -88,16 +91,19 @@ describe("mint with seed feature", () => {
     let minterContract: SeededSingleEditionMintable;
 
     beforeEach(async () => {
-      await dynamicSketch.createSeededEdition(
-        "Testing Token",
-        "TEST",
-        "This is a testing token for all",
-        defaultVersion(),
-        10,
-        10
+      await dynamicSketch.createEdition(
+        editionData(
+          "Testing Token",
+          "TEST",
+          "This is a testing token for all",
+          defaultVersion(),
+          10,
+          10
+        ),
+        Implementation.seededEditions
       );
 
-      const editionResult = await dynamicSketch.getSeededEditionAtId(0);
+      const editionResult = await dynamicSketch.getEditionAtId(0, Implementation.seededEditions);
       minterContract = (await ethers.getContractAt(
         "SeededSingleEditionMintable",
         editionResult
@@ -139,16 +145,19 @@ describe("mint with seed feature", () => {
     let minterContract: SeededSingleEditionMintable;
 
     beforeEach(async () => {
-      await dynamicSketch.createSeededEdition(
-        "Testing Token",
-        "TEST",
-        "This is a testing token for all",
-        defaultVersion(),
-        10,
-        10
+      await dynamicSketch.createEdition(
+        editionData(
+          "Testing Token",
+          "TEST",
+          "This is a testing token for all",
+          defaultVersion(),
+          10,
+          10
+        ),
+        Implementation.seededEditions
       );
 
-      const editionResult = await dynamicSketch.getSeededEditionAtId(0);
+      const editionResult = await dynamicSketch.getEditionAtId(0, Implementation.seededEditions);
       minterContract = (await ethers.getContractAt(
         "SeededSingleEditionMintable",
         editionResult
@@ -193,16 +202,19 @@ describe("mint with seed feature", () => {
     let oneEth = ethers.utils.parseEther("1")
 
     beforeEach(async () => {
-      await dynamicSketch.createSeededEdition(
-        "Testing Token",
-        "TEST",
-        "This is a testing token for all",
-        defaultVersion(),
-        10,
-        10
+      await dynamicSketch.createEdition(
+        editionData(
+          "Testing Token",
+          "TEST",
+          "This is a testing token for all",
+          defaultVersion(),
+          10,
+          10
+        ),
+        Implementation.seededEditions
       );
 
-      const editionResult = await dynamicSketch.getSeededEditionAtId(0);
+      const editionResult = await dynamicSketch.getEditionAtId(0, Implementation.seededEditions);
       minterContract = (await ethers.getContractAt(
         "SeededSingleEditionMintable",
         editionResult

--- a/test/SingleEditionMintableTest.ts
+++ b/test/SingleEditionMintableTest.ts
@@ -8,9 +8,12 @@ import {
   SingleEditionMintableCreator,
   SingleEditionMintable,
 } from "../typechain";
-import { BigNumberish } from "ethers";
 
-type Label = [BigNumberish, BigNumberish, BigNumberish]
+import {
+  editionData,
+  Implementation,
+  Label
+} from "./utils"
 
 const defaultVersion = () => {
   return {
@@ -54,16 +57,19 @@ describe("SingleEditionMintable", () => {
 
   it("makes a new edition", async () => {
     await dynamicSketch.createEdition(
-      "Testing Token",
-      "TEST",
-      "This is a testing token for all",
-      defaultVersion(),
-      // 1% royalty since BPS
-      10,
-      10
+      editionData(
+        "Testing Token",
+        "TEST",
+        "This is a testing token for all",
+        defaultVersion(),
+        // 1% royalty since BPS
+        10,
+        10
+      ),
+      Implementation.editions
     );
 
-    const editionResult = await dynamicSketch.getEditionAtId(0);
+    const editionResult = await dynamicSketch.getEditionAtId(0, Implementation.editions);
     const minterContract = (await ethers.getContractAt(
       "SingleEditionMintable",
       editionResult
@@ -91,17 +97,19 @@ describe("SingleEditionMintable", () => {
     beforeEach(async () => {
       signer1 = (await ethers.getSigners())[1];
       await dynamicSketch.createEdition(
-        "Testing Token",
-        "TEST",
-        "This is a testing token for all",
-        defaultVersion(),
-        // 1% royalty since BPS
-        10,
-        10
+        editionData(
+          "Testing Token",
+          "TEST",
+          "This is a testing token for all",
+          defaultVersion(),
+          // 1% royalty since BPS
+          10,
+          10
+        ),
+        Implementation.editions
       );
 
-      const editionResult = await dynamicSketch.getEditionAtId(0);
-      console.log(editionResult)
+      const editionResult = await dynamicSketch.getEditionAtId(0, Implementation.editions);
       minterContract = (await ethers.getContractAt(
         "SingleEditionMintable",
         editionResult
@@ -151,16 +159,19 @@ describe("SingleEditionMintable", () => {
     it("creates an unbounded edition", async () => {
       // no limit for edition size
       await dynamicSketch.createEdition(
-        "Testing Token",
-        "TEST",
-        "This is a testing token for all",
-        defaultVersion(),
-        // 1% royalty since BPS
-        0,
-        0
+        editionData(
+          "Testing Token",
+          "TEST",
+          "This is a testing token for all",
+          defaultVersion(),
+          // 1% royalty since BPS
+          0,
+          0
+        ),
+        Implementation.editions
       );
 
-      const editionResult = await dynamicSketch.getEditionAtId(1);
+      const editionResult = await dynamicSketch.getEditionAtId(1, Implementation.editions);
       minterContract = (await ethers.getContractAt(
         "SingleEditionMintable",
         editionResult
@@ -310,16 +321,19 @@ describe("SingleEditionMintable", () => {
       });
       it("sets the correct royalty amount", async () => {
         await dynamicSketch.createEdition(
-          "Testing Token",
-          "TEST",
-          "This is a testing token for all",
-          defaultVersion(),
-          // 2% royalty since BPS
-          200,
-          200
+          editionData(
+            "Testing Token",
+            "TEST",
+            "This is a testing token for all",
+            defaultVersion(),
+            // 2% royalty since BPS
+            200,
+            200
+          ),
+          Implementation.editions
         );
     
-        const editionResult = await dynamicSketch.getEditionAtId(1);
+        const editionResult = await dynamicSketch.getEditionAtId(1, Implementation.editions);
         const minterContractNew = (await ethers.getContractAt(
           "SingleEditionMintable",
           editionResult
@@ -334,15 +348,19 @@ describe("SingleEditionMintable", () => {
     it("mints a large batch", async () => {
       // no limit for edition size
       await dynamicSketch.createEdition(
-        "Testing Token",
-        "TEST",
-        "This is a testing token for all",
-        defaultVersion(),
-        0,
-        0
+        editionData(
+          "Testing Token",
+          "TEST",
+          "This is a testing token for all",
+          defaultVersion(),
+          // 1% royalty since BPS
+          0,
+          0
+        ),
+        Implementation.editions
       );
 
-      const editionResult = await dynamicSketch.getEditionAtId(1);
+      const editionResult = await dynamicSketch.getEditionAtId(1, Implementation.editions);
       minterContract = (await ethers.getContractAt(
         "SingleEditionMintable",
         editionResult
@@ -692,15 +710,18 @@ describe("SingleEditionMintable", () => {
       });
       it("emits version added event on creation", async () => {
         await dynamicSketch.createEdition(
-          "Testing Token",
-          "TEST",
-          "This is a testing token for all",
-          defaultVersion(),
-          // 1% royalty since BPS
-          10,
-          10
+          editionData(
+            "Testing Token",
+            "TEST",
+            "This is a testing token for all",
+            defaultVersion(),
+            // 1% royalty since BPS
+            10,
+            10
+          ),
+          Implementation.editions
         )
-        const editionResult = await dynamicSketch.getEditionAtId(1);
+        const editionResult = await dynamicSketch.getEditionAtId(1, Implementation.editions);
         const newMinterContract = (await ethers.getContractAt(
           "SingleEditionMintable",
           editionResult

--- a/test/SingleEditionMintableTest.ts
+++ b/test/SingleEditionMintableTest.ts
@@ -101,6 +101,7 @@ describe("SingleEditionMintable", () => {
       );
 
       const editionResult = await dynamicSketch.getEditionAtId(0);
+      console.log(editionResult)
       minterContract = (await ethers.getContractAt(
         "SingleEditionMintable",
         editionResult

--- a/test/SingleEditionPurchaseMintableTest.ts
+++ b/test/SingleEditionPurchaseMintableTest.ts
@@ -9,6 +9,12 @@ import {
   SingleEditionMintable,
 } from "../typechain";
 
+import {
+  editionData,
+  Implementation,
+  Label
+} from "./utils"
+
 describe("SingleEditionMintable", () => {
   let signer: SignerWithAddress;
   let signerAddress: string;
@@ -33,27 +39,30 @@ describe("SingleEditionMintable", () => {
 
   it("purchases a edition", async () => {
     await dynamicSketch.createEdition(
-      "Testing Token",
-      "TEST",
-      "This is a testing token for all",
-      {
-        urls: [
-          {
-            url: "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy",
-            sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000001"
-          },
-          {
-            url: "",
-            sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-          }
-        ],
-        label: [0,0,1]
-      },
-      10,
-      10
+      editionData(
+        "Testing Token",
+        "TEST",
+        "This is a testing token for all",
+        {
+          urls: [
+            {
+              url: "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy",
+              sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000001"
+            },
+            {
+              url: "",
+              sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            }
+          ],
+          label: [0,0,1]
+        },
+        10,
+        10
+      ),
+      Implementation.editions
     );
 
-    const editionResult = await dynamicSketch.getEditionAtId(0);
+    const editionResult = await dynamicSketch.getEditionAtId(0, Implementation.editions);
     const minterContract = (await ethers.getContractAt(
       "SingleEditionMintable",
       editionResult

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,4 @@
-import {utils} from "ethers"
+import {utils , BigNumberish} from "ethers"
 import {URL} from "url"
 export const getSeed = (tokenId: number, tokenAddress: string) => {
   const hash = utils.keccak256(
@@ -25,3 +25,34 @@ export const parseUrlQuery = (url: string) => {
     address
   }
 }
+
+export enum Implementation {
+  editions,
+  seededEditions
+}
+
+export interface Version {
+  urls: {
+    url: string;
+    sha256hash: string;
+  }[];
+  label: Label;
+}
+
+export type Label = [BigNumberish, BigNumberish, BigNumberish]
+
+export const editionData = (
+  name: string,
+  symbol: string,
+  description: string,
+  version: Version,
+  editionSize: BigNumberish,
+  royaltyBPS: BigNumberish
+) => ({
+  name,
+  symbol,
+  description,
+  version,
+  editionSize,
+  royaltyBPS
+})


### PR DESCRIPTION
Another attempt at solving issue #5 

This time use two separate contracts. One for normal editions and one for seeded editions. The creator(artists) would choose which type to create either calling **createEdition()** or **createSeededEdition()** on the singleEditionMintableCreator contract.

This implementation gets rid of the need to auto assign seeds and the gas guzzling for-loops see pull request #7

### Notable changes:
- **SingleEditionMintableCreator.sol** is now a factory contract with two possible types of edition contracts. With separate Id counters and functions for each.
- **SharedNFTLogic** functions tokenMediaData() and createMetadataEdition() have overloads with a uint256 that adds a seed to the image and animation url's
- **SeededSingleEditionMintable.sol** is a copy of SingleEditionMintable.sol with changes to the minting functions so that a seed must be chosen
- **SeededSingleEditionMintableTests.ts** contains new tests for the differences made