### PR TITLE
Add more implementations

### DIFF
--- a/contracts/SingleEditionMintableCreator.sol
+++ b/contracts/SingleEditionMintableCreator.sol
@@ -42,6 +42,13 @@ contract SingleEditionMintableCreator {
         uint256 royaltyBPS; /// BPS amount of royalty
     }
 
+    modifier onlyOwner {
+        require(msg.sender == owner, "Only owner can call this function.");
+        _;
+    }
+
+    address public owner;
+
     /// Counter for current contract id upgraded
     mapping(uint8 => CountersUpgradeable.Counter) private atContracts;
 
@@ -52,9 +59,10 @@ contract SingleEditionMintableCreator {
     /// Initializes factory with address of implementations logic
     /// @param _implementations Array of addresse for implementations of SingleEditionMintable like contracts to clone
     constructor(address[] memory _implementations) {
+        owner = address(msg.sender);
         for (uint8 i = 0; i < _implementations.length; i++) {
             implementations.push(_implementations[i]);
-            atContracts[i] = CountersUpgradeable.Counter(1);
+            atContracts[i] = CountersUpgradeable.Counter(0);
         }
     }
 
@@ -114,7 +122,19 @@ contract SingleEditionMintableCreator {
             );
     }
 
-    // TODO: addImplementation(address) onlyDeployer
+    function addImplementation(address implementation)
+        external
+        onlyOwner
+        returns (uint256)
+    {
+        // initilize counter for implementation
+        atContracts[uint8(implementations.length)] = CountersUpgradeable.Counter(0);
+        // add implementation to clonable implementations
+        implementations.push(implementation);
+
+        return implementations.length;
+    }
+
     // TODO: event ImplemnetationAdded(address implementation)
 
     /// Emitted when a edition is created reserving the corresponding token IDs.

--- a/contracts/SingleEditionMintableCreator.sol
+++ b/contracts/SingleEditionMintableCreator.sol
@@ -132,10 +132,18 @@ contract SingleEditionMintableCreator {
         // add implementation to clonable implementations
         implementations.push(implementation);
 
+        emit ImplemnetationAdded(
+            implementation,
+            uint8(implementations.length - 1)
+        );
+
         return implementations.length;
     }
 
-    // TODO: event ImplemnetationAdded(address implementation)
+    event ImplemnetationAdded(
+        address indexed implementationContractAddress,
+        uint8 implementation
+    );
 
     /// Emitted when a edition is created reserving the corresponding token IDs.
     /// @param editionId ID of newly created edition

--- a/contracts/SingleEditionMintableCreator.sol
+++ b/contracts/SingleEditionMintableCreator.sol
@@ -43,9 +43,7 @@ contract SingleEditionMintableCreator {
     }
 
     /// Counter for current contract id upgraded
-    // TODO: test this counters work independently
     mapping(uint8 => CountersUpgradeable.Counter) private atContracts;
-    // CountersUpgradeable.Counter[] private atContracts;
 
     /// Address for implementation of SingleEditionMintable to clone
     // TODO: a mapping with implementation name may clearer?
@@ -56,7 +54,7 @@ contract SingleEditionMintableCreator {
     constructor(address[] memory _implementations) {
         for (uint8 i = 0; i < _implementations.length; i++) {
             implementations.push(_implementations[i]);
-            atContracts[i] = CountersUpgradeable.Counter(0);
+            atContracts[i] = CountersUpgradeable.Counter(1);
         }
     }
 
@@ -67,8 +65,7 @@ contract SingleEditionMintableCreator {
         EditionData memory editionData,
         uint8 implementation
     ) external returns (uint256) {
-        // TODO: add require statment to check implementation exists
-        // require(implementations[implementation] != address(0), "EditionMintable implementation does not exist");
+        require(implementations.length > implementation, "implementation does not exist");
 
         uint256 newId = atContracts[implementation].current();
         address newContract = ClonesUpgradeable.cloneDeterministic(
@@ -87,10 +84,17 @@ contract SingleEditionMintableCreator {
             editionData.royaltyBPS
         );
 
-        emit CreatedEdition(newId, msg.sender, editionData.editionSize, newContract, implementation);
-        // Returns the ID of the recently created minting contract
-        // Also increments for the next contract creation call
+        emit CreatedEdition(
+            newId,
+            msg.sender,
+            editionData.editionSize,
+            newContract,
+            implementation
+        );
+
+        // increment for the next contract creation call
         atContracts[implementation].increment();
+
         return newId;
     }
 

--- a/test/SingleEditionMintableCreator.ts
+++ b/test/SingleEditionMintableCreator.ts
@@ -208,6 +208,18 @@ describe("SingleEditionMintableCreator", () => {
       ).to.be.equal(anotherNewImplementation.address)
     })
 
+    it("emits ImplemnetationAdded event", async () => {
+      await expect(
+        creatorContract.addImplementation(newImplementation.address)
+      ).to.emit(
+        creatorContract,
+        "ImplemnetationAdded"
+      ).withArgs(
+        newImplementation.address,
+        2
+      )
+    })
+
   })
 
 })

--- a/test/SingleEditionMintableCreator.ts
+++ b/test/SingleEditionMintableCreator.ts
@@ -1,0 +1,158 @@
+import { expect } from "chai";
+// import "@nomiclabs/hardhat-ethers";
+import { ethers, deployments } from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import parseDataURI from "data-urls";
+
+import {
+  SingleEditionMintableCreator,
+  SingleEditionMintable,
+  SeededSingleEditionMintable
+} from "../typechain";
+
+import {
+  editionData,
+  Implementation,
+  Label
+} from "./utils"
+
+
+const defaultVersion = () => {
+  return {
+    urls: [
+      // image
+      {
+        url: "",
+        sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+      },
+      // animation
+      {
+        url: "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy",
+        sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      },
+    ],
+    label: [0,0,1] as Label
+  }
+}
+
+const defualtEditionData = editionData(
+  "Testing Token",
+  "TEST",
+  "This is a testing token for all",
+  defaultVersion(),
+  10,
+  10
+)
+
+describe.only("SingleEditionMintable", () => {
+  let signer: SignerWithAddress;
+  let signerAddress: string;
+  let creatorContract: SingleEditionMintableCreator;
+
+  beforeEach(async () => {
+    const { SingleEditionMintableCreator } = await deployments.fixture([
+      "SingleEditionMintableCreator",
+      "SingleEditionMintable",
+    ]);
+
+    creatorContract = (await ethers.getContractAt(
+      "SingleEditionMintableCreator",
+      SingleEditionMintableCreator.address
+    )) as SingleEditionMintableCreator
+
+    signer = (await ethers.getSigners())[0]
+    signerAddress = await signer.getAddress()
+  })
+
+  describe("#createEdition", () => {
+    it("creates new edition with singleEditionMintable implementation", async () => {
+      await creatorContract.createEdition(
+        defualtEditionData,
+        Implementation.editions
+      )
+      const editionConractAddress01 = await creatorContract.getEditionAtId(1, Implementation.editions)
+      const editionsContract01 = (await ethers.getContractAt(
+        "SingleEditionMintable",
+        editionConractAddress01
+      )) as SingleEditionMintable;
+
+      // check supports SingleEditionMintable interface
+      expect(
+        await editionsContract01.supportsInterface("0x2fc51e5a")
+      ).to.be.true
+    })
+
+    it("creates new edition with seededSingleEditionMintable implementation", async () => {
+      await creatorContract.createEdition(
+        defualtEditionData,
+        Implementation.seededEditions
+      )
+      const editionConractAddress02 = await creatorContract.getEditionAtId(1, Implementation.seededEditions)
+      const editionsContract02 = (await ethers.getContractAt(
+        "SingleEditionMintable",
+        editionConractAddress02
+      )) as SeededSingleEditionMintable;
+
+      // check supports SeededSingleEditionMintable interface
+      expect(
+        await editionsContract02.supportsInterface("0x26057e5e")
+      ).to.be.true
+    })
+
+    it("should increment a seperate id counter for each implementation", async () => {
+
+       // create first edition
+      await creatorContract.createEdition(
+        defualtEditionData,
+        Implementation.editions
+      )
+
+      // create second edition
+      let expectedAddress = await creatorContract.getEditionAtId(2, Implementation.editions)
+      await expect(
+        creatorContract.createEdition(
+          defualtEditionData,
+          Implementation.editions
+        )
+      ).to.emit(
+        creatorContract,
+        "CreatedEdition"
+      ).withArgs(
+          2,                // id
+          signerAddress,    // creator
+          10,               // edition size
+          expectedAddress,
+          Implementation.editions
+        )
+
+      // create first seeded edition
+      expectedAddress = await creatorContract.getEditionAtId(1, Implementation.seededEditions)
+      await expect(
+        creatorContract.createEdition(
+          defualtEditionData,
+          Implementation.seededEditions
+        )
+      ).to.emit(
+        creatorContract,
+        "CreatedEdition"
+      ).withArgs(
+          1,              // id
+          signerAddress,  // creator
+          10,             // edition size
+          expectedAddress,
+          Implementation.seededEditions
+        )
+    })
+    it("reverts if implementation doesn't exist", async () => {
+      await expect(
+        creatorContract.createEdition(
+          defualtEditionData,
+          3
+        )
+      ).to.be.revertedWith("implementation does not exist")
+    })
+  })
+
+  // TODO: add implementation
+
+})


### PR DESCRIPTION
Attempts to solve #11

- Removes hard coded implementations of contracts
- adds function for the deployer of the contract *(olta)* to add more implementations
- a seperate id counter for each implementation
- emits an `ImplementationAdded` event
