### PR TITLE
add patch notes to meta data

### DIFF
--- a/contracts/SeededSingleEditionMintable.sol
+++ b/contracts/SeededSingleEditionMintable.sol
@@ -71,7 +71,8 @@ contract SeededSingleEditionMintable is
     // Media Urls
     enum URLS  {
         Image,
-        Animation
+        Animation,
+        PatchNotes
     }
     // Versions of Media Urls
     Versions.Set private versions;
@@ -371,6 +372,8 @@ contract SeededSingleEditionMintable is
             string memory,
             bytes32,
             string memory,
+            bytes32,
+            string memory,
             bytes32
         )
     {
@@ -379,7 +382,9 @@ contract SeededSingleEditionMintable is
             latest.urls[uint8(URLS.Image)].url,
             latest.urls[uint8(URLS.Image)].sha256hash,
             latest.urls[uint8(URLS.Animation)].url,
-            latest.urls[uint8(URLS.Animation)].sha256hash
+            latest.urls[uint8(URLS.Animation)].sha256hash,
+            latest.urls[uint8(URLS.PatchNotes)].url,
+            latest.urls[uint8(URLS.PatchNotes)].sha256hash
         );
     }
 
@@ -401,6 +406,8 @@ contract SeededSingleEditionMintable is
             string memory,
             bytes32,
             string memory,
+            bytes32,
+            string memory,
             bytes32
         )
     {
@@ -409,7 +416,9 @@ contract SeededSingleEditionMintable is
             version.urls[uint8(URLS.Image)].url,
             version.urls[uint8(URLS.Image)].sha256hash,
             version.urls[uint8(URLS.Animation)].url,
-            version.urls[uint8(URLS.Animation)].sha256hash
+            version.urls[uint8(URLS.Animation)].sha256hash,
+            version.urls[uint8(URLS.PatchNotes)].url,
+            version.urls[uint8(URLS.PatchNotes)].sha256hash
         );
     }
 
@@ -449,6 +458,7 @@ contract SeededSingleEditionMintable is
                 MediaData(
                     version.urls[uint8(URLS.Image)].url,
                     version.urls[uint8(URLS.Animation)].url,
+                    version.urls[uint8(URLS.PatchNotes)].url,
                     version.label
                 ),
                 tokenId,
@@ -482,6 +492,7 @@ contract SeededSingleEditionMintable is
                 MediaData(
                     version.urls[uint8(URLS.Image)].url,
                     version.urls[uint8(URLS.Animation)].url,
+                    version.urls[uint8(URLS.PatchNotes)].url,
                     version.label
                 ),
                 tokenId,

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -196,20 +196,18 @@ contract SharedNFTLogic is IPublicSharedMetadata {
             return
                 string(
                     abi.encodePacked(
-                        'image": "',
-                        media.imageUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        '", "animation_url": "',
-                        media.animationUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        "&address=",
-                        addressToString(tokenAddress),
-                        '", "',
-                        'media_version": "',
-                        uintArray3ToString(media.label),
-                        '", "'
+                        imageUrl(
+                            media.imageUrl,
+                            tokenOfEdition
+                        ),
+                        animationUrl(
+                            media.animationUrl,
+                            tokenOfEdition,
+                            tokenAddress
+                        ),
+                        version(
+                            media.label
+                        )
                     )
                 );
         }
@@ -217,14 +215,13 @@ contract SharedNFTLogic is IPublicSharedMetadata {
             return
                 string(
                     abi.encodePacked(
-                        'image": "',
-                        media.imageUrl,
-                        "?id=", // if just url "/id" this will work with arweave pathmanifests
-                        numberToString(tokenOfEdition),
-                        '", "',
-                        'media_version": "',
-                        uintArray3ToString(media.label),
-                        '", "'
+                        imageUrl(
+                            media.imageUrl,
+                            tokenOfEdition
+                        ),
+                        version(
+                            media.label
+                        )
                     )
                 );
         }
@@ -232,16 +229,14 @@ contract SharedNFTLogic is IPublicSharedMetadata {
             return
                 string(
                     abi.encodePacked(
-                        'animation_url": "',
-                        media.animationUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        "&address=",
-                        addressToString(tokenAddress),
-                        '", "',
-                        'media_version": "',
-                        uintArray3ToString(media.label),
-                        '", "'
+                        animationUrl(
+                            media.animationUrl,
+                            tokenOfEdition,
+                            tokenAddress
+                        ),
+                        version(
+                            media.label
+                        )
                     )
                 );
         }
@@ -264,22 +259,19 @@ contract SharedNFTLogic is IPublicSharedMetadata {
             return
                 string(
                     abi.encodePacked(
-                        'image": "',
-                        media.imageUrl,
-                        "?seed=",
-                        numberToString(tokenSeed),
-                        '", "animation_url": "',
-                        media.animationUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        "&address=",
-                        addressToString(tokenAddress),
-                        "&seed=",
-                        numberToString(tokenSeed),
-                        '", "',
-                        'media_version": "',
-                        uintArray3ToString(media.label),
-                        '", "'
+                        imageUrl(
+                            media.imageUrl,
+                            tokenSeed
+                        ),
+                        animationUrl(
+                            media.animationUrl,
+                            tokenOfEdition,
+                            tokenAddress,
+                            tokenSeed
+                        ),
+                        version(
+                            media.label
+                        )
                     )
                 );
         }
@@ -287,14 +279,13 @@ contract SharedNFTLogic is IPublicSharedMetadata {
             return
                 string(
                     abi.encodePacked(
-                        'image": "',
-                        media.imageUrl,
-                        "?seed=", // if just url "/id" this will work with arweave pathmanifests
-                        numberToString(tokenSeed),
-                        '", "',
-                        'media_version": "',
-                        uintArray3ToString(media.label),
-                        '", "'
+                        imageUrl(
+                            media.imageUrl,
+                            tokenSeed
+                        ),
+                        version(
+                            media.label
+                        )
                     )
                 );
         }
@@ -302,22 +293,85 @@ contract SharedNFTLogic is IPublicSharedMetadata {
             return
                 string(
                     abi.encodePacked(
-                        'animation_url": "',
-                        media.animationUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        "&address=",
-                        addressToString(tokenAddress),
-                        "&seed=",
-                        numberToString(tokenSeed),
-                        '", "',
-                        'media_version": "',
-                        uintArray3ToString(media.label),
-                        '", "'
+                        animationUrl(
+                            media.animationUrl,
+                            tokenOfEdition,
+                            tokenAddress,
+                            tokenSeed
+                        ),
+                        version(
+                            media.label
+                        )
                     )
                 );
         }
 
         return "";
+    }
+
+    function version(
+        uint8[3] memory label
+    ) public pure returns (string memory) {
+        return string (
+            abi.encodePacked(
+                'media_version": "',
+                uintArray3ToString(label),
+                '", "'
+            )
+        );
+    }
+
+    function imageUrl(
+        string memory url,
+        uint256 id
+    ) public pure returns (string memory) {
+        return string (
+            abi.encodePacked(
+                'image": "',
+                url,
+                 "?id=", // if just url "/id" this will work with arweave pathmanifests
+                numberToString(id),
+                '", "'
+            )
+        );
+    }
+
+    function animationUrl(
+        string memory url,
+        uint256 tokenId,
+        address tokenAddress
+    ) public pure returns (string memory) {
+        return string (
+            abi.encodePacked(
+                'animation_url": "',
+                url,
+                "?id=",
+                numberToString(tokenId),
+                "&address=",
+                addressToString(tokenAddress),
+                '", "'
+            )
+        );
+    }
+
+    function animationUrl(
+        string memory url,
+        uint256 tokenId,
+        address tokenAddress,
+        uint256 seed
+    ) public pure returns (string memory) {
+        return string (
+            abi.encodePacked(
+                'animation_url": "',
+                url,
+                "?id=",
+                numberToString(tokenId),
+                "&address=",
+                addressToString(tokenAddress),
+                "&seed=",
+                numberToString(seed),
+                '", "'
+            )
+        );
     }
 }

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -10,6 +10,7 @@ import {Versions} from "./Versions.sol";
 struct MediaData{
     string imageUrl;
     string animationUrl;
+    string patchNotesUrl;
     uint8[3] label;
 }
 
@@ -206,7 +207,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                             tokenAddress
                         ),
                         version(
-                            media.label
+                            media.label,
+                            media.patchNotesUrl
                         )
                     )
                 );
@@ -220,7 +222,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                             tokenOfEdition
                         ),
                         version(
-                            media.label
+                            media.label,
+                            media.patchNotesUrl
                         )
                     )
                 );
@@ -235,7 +238,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                             tokenAddress
                         ),
                         version(
-                            media.label
+                            media.label,
+                            media.patchNotesUrl
                         )
                     )
                 );
@@ -270,7 +274,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                             tokenSeed
                         ),
                         version(
-                            media.label
+                            media.label,
+                            media.patchNotesUrl
                         )
                     )
                 );
@@ -284,7 +289,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                             tokenSeed
                         ),
                         version(
-                            media.label
+                            media.label,
+                            media.patchNotesUrl
                         )
                     )
                 );
@@ -300,7 +306,8 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                             tokenSeed
                         ),
                         version(
-                            media.label
+                            media.label,
+                            media.patchNotesUrl
                         )
                     )
                 );
@@ -310,12 +317,16 @@ contract SharedNFTLogic is IPublicSharedMetadata {
     }
 
     function version(
-        uint8[3] memory label
+        uint8[3] memory label,
+        string memory patchNotesUrl
     ) public pure returns (string memory) {
         return string (
             abi.encodePacked(
                 'media_version": "',
                 uintArray3ToString(label),
+                '", "'
+                'patch_notes": "',
+                patchNotesUrl,
                 '", "'
             )
         );

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -53,11 +53,10 @@ contract SingleEditionMintable is
     string public description;
 
     // Media Urls
-    // animation_url and image_url metadata
-    // TODO: swap these around and test they match
     enum URLS  {
         Image,
-        Animation
+        Animation,
+        PatchNotes
     }
     // Versions of Media Urls
     Versions.Set private versions;
@@ -313,6 +312,8 @@ contract SingleEditionMintable is
             string memory,
             bytes32,
             string memory,
+            bytes32,
+            string memory,
             bytes32
         )
     {
@@ -321,7 +322,9 @@ contract SingleEditionMintable is
             latest.urls[uint8(URLS.Image)].url,
             latest.urls[uint8(URLS.Image)].sha256hash,
             latest.urls[uint8(URLS.Animation)].url,
-            latest.urls[uint8(URLS.Animation)].sha256hash
+            latest.urls[uint8(URLS.Animation)].sha256hash,
+            latest.urls[uint8(URLS.PatchNotes)].url,
+            latest.urls[uint8(URLS.PatchNotes)].sha256hash
         );
     }
 
@@ -340,6 +343,8 @@ contract SingleEditionMintable is
             string memory,
             bytes32,
             string memory,
+            bytes32,
+            string memory,
             bytes32
         )
     {
@@ -348,7 +353,9 @@ contract SingleEditionMintable is
             version.urls[uint8(URLS.Image)].url,
             version.urls[uint8(URLS.Image)].sha256hash,
             version.urls[uint8(URLS.Animation)].url,
-            version.urls[uint8(URLS.Animation)].sha256hash
+            version.urls[uint8(URLS.Animation)].sha256hash,
+            version.urls[uint8(URLS.PatchNotes)].url,
+            version.urls[uint8(URLS.PatchNotes)].sha256hash
         );
     }
 
@@ -389,6 +396,7 @@ contract SingleEditionMintable is
                 MediaData(
                     version.urls[uint8(URLS.Image)].url,
                     version.urls[uint8(URLS.Animation)].url,
+                    version.urls[uint8(URLS.PatchNotes)].url,
                     version.label
                 ),
                 tokenId,
@@ -421,6 +429,7 @@ contract SingleEditionMintable is
                 MediaData(
                     version.urls[uint8(URLS.Image)].url,
                     version.urls[uint8(URLS.Animation)].url,
+                    version.urls[uint8(URLS.PatchNotes)].url,
                     version.label
                 ),
                 tokenId,

--- a/test/SeededSingleEditionMintableTest.ts
+++ b/test/SeededSingleEditionMintableTest.ts
@@ -32,6 +32,11 @@ const defaultVersion = () => {
         url: defaultAnimationURl,
         sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
       },
+      // patch notes
+      {
+        url: "",
+        sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      },
     ],
     label: [0,0,1] as Label
   }
@@ -66,7 +71,7 @@ const expectedUrl = (contract: SeededSingleEditionMintable, id: number, seed: nu
 
 const createMintData = (to: string, seed: number) => ({to, seed})
 
-describe("mint with seed feature", () => {
+describe("SeededSingleEditionMintable", () => {
   let signer: SignerWithAddress;
   let signerAddress: string;
   let dynamicSketch: SingleEditionMintableCreator;
@@ -87,7 +92,7 @@ describe("mint with seed feature", () => {
     signerAddress = await signer.getAddress();
   });
 
-  describe("# mintEdition", () => {
+  describe("#mintEdition", () => {
     let minterContract: SeededSingleEditionMintable;
 
     beforeEach(async () => {
@@ -140,7 +145,7 @@ describe("mint with seed feature", () => {
 
   });
 
-  describe("# mintEditions", () => {
+  describe("#mintEditions", () => {
 
     let minterContract: SeededSingleEditionMintable;
 
@@ -197,7 +202,7 @@ describe("mint with seed feature", () => {
     });
   });
 
-  describe("# purchase", () => {
+  describe("#purchase", () => {
     let minterContract: SeededSingleEditionMintable;
     let oneEth = ethers.utils.parseEther("1")
 

--- a/test/SingleEditionMintableTest.ts
+++ b/test/SingleEditionMintableTest.ts
@@ -28,6 +28,11 @@ const defaultVersion = () => {
         url: "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy",
         sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
       },
+      // patch notes
+      {
+        url: "",
+        sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      },
     ],
     label: [0,0,1] as Label
   }
@@ -152,6 +157,7 @@ describe("SingleEditionMintable", () => {
             "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=1"
             + `&address=${minterContract.address.toLowerCase()}`,
           media_version: "0.0.1",
+          patch_notes: "",
           properties: { number: 1, name: "Testing Token" },
         })
       );
@@ -230,6 +236,7 @@ describe("SingleEditionMintable", () => {
             "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=1"
             + `&address=${minterContract.address.toLowerCase()}`,
           media_version: "0.0.1",
+          patch_notes: "",
           properties: { number: 1, name: "Testing Token" },
         })
       );
@@ -332,7 +339,7 @@ describe("SingleEditionMintable", () => {
           ),
           Implementation.editions
         );
-    
+
         const editionResult = await dynamicSketch.getEditionAtId(1, Implementation.editions);
         const minterContractNew = (await ethers.getContractAt(
           "SingleEditionMintable",
@@ -422,6 +429,7 @@ describe("SingleEditionMintable", () => {
             "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy?id=10"
             + `&address=${minterContract.address.toLowerCase()}`,
           media_version: "0.0.1",
+          patch_notes: "",
           properties: { number: 10, name: "Testing Token" },
         })
       );
@@ -446,6 +454,10 @@ describe("SingleEditionMintable", () => {
               {
                 url: "https://arweave.net/fnfNerUHj64h-J2yU9d-rZ6ZBAQRhrWfkw_fgiKyl2k",
                 sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                url: "",
+                sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
               },
               {
                 url: "",
@@ -485,6 +497,10 @@ describe("SingleEditionMintable", () => {
                   {
                     url: "animationUrl",
                     sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000001",
+                  },
+                  {
+                    url: "patchNotesUrl",
+                    sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000001"
                   }
                 ],
                 label: [0,0,2]
@@ -498,6 +514,8 @@ describe("SingleEditionMintable", () => {
               'imageUrl',
               '0x0000000000000000000000000000000000000000000000000000000000000001',
               'animationUrl',
+              '0x0000000000000000000000000000000000000000000000000000000000000001',
+              'patchNotesUrl',
               '0x0000000000000000000000000000000000000000000000000000000000000001'
             ]
           )
@@ -558,7 +576,7 @@ describe("SingleEditionMintable", () => {
           await expect(
             minterContract.updateVersionURL(
               [0,0,1],
-              2,
+              3,
               "updatedImageURL"
             )
           ).to.be.revertedWith("#Versions: The url does not exist on that version")
@@ -585,7 +603,9 @@ describe("SingleEditionMintable", () => {
             "",
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "updatedAnimationURL",
-            "0x0000000000000000000000000000000000000000000000000000000000000000"
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
           ])
 
           // Update image URL
@@ -607,7 +627,9 @@ describe("SingleEditionMintable", () => {
             "updatedImageURL",
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "updatedAnimationURL",
-            "0x0000000000000000000000000000000000000000000000000000000000000000"
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
           ])
         });
       });
@@ -631,7 +653,11 @@ describe("SingleEditionMintable", () => {
                 {
                   url: "https://arweave.net/fnfNerUHj64h-J2yU9d-rZ6ZBAQRhrWfkw_fgiKyl2k",
                   sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000001"
-                }
+                },
+                {
+                  url: "",
+                  sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                },
               ],
               label: [0,0,2]
             },
@@ -644,7 +670,9 @@ describe("SingleEditionMintable", () => {
             "",
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy",
-            "0x0000000000000000000000000000000000000000000000000000000000000000"
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
           ])
           // version 0.0.2
           expect(
@@ -653,7 +681,9 @@ describe("SingleEditionMintable", () => {
             "",
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "https://arweave.net/fnfNerUHj64h-J2yU9d-rZ6ZBAQRhrWfkw_fgiKyl2k",
-            "0x0000000000000000000000000000000000000000000000000000000000000001"
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
           ])
 
         })
@@ -670,6 +700,10 @@ describe("SingleEditionMintable", () => {
               {
                 url: "https://arweave.net/fnfNerUHj64h-J2yU9d-rZ6ZBAQRhrWfkw_fgiKyl2k",
                 sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                url: "",
+                sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
               }
             ],
             label: [0,0,2]
@@ -688,7 +722,11 @@ describe("SingleEditionMintable", () => {
                 [
                   "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy",
                   "0x0000000000000000000000000000000000000000000000000000000000000000"
-                ]
+                ],
+                [
+                  "",
+                  "0x0000000000000000000000000000000000000000000000000000000000000000"
+                ],
               ],
               [0, 0, 1]
             ],
@@ -701,7 +739,11 @@ describe("SingleEditionMintable", () => {
                 [
                   "https://arweave.net/fnfNerUHj64h-J2yU9d-rZ6ZBAQRhrWfkw_fgiKyl2k",
                   "0x0000000000000000000000000000000000000000000000000000000000000001"
-                ]
+                ],
+                [
+                  "",
+                  "0x0000000000000000000000000000000000000000000000000000000000000000"
+                ],
               ],
               [0, 0, 2]
             ]
@@ -746,7 +788,11 @@ describe("SingleEditionMintable", () => {
                 {
                   url: "https://arweave.net/fnfNerUHj64h-J2yU9d-rZ6ZBAQRhrWfkw_fgiKyl2k",
                   sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000001"
-                }
+                },
+                {
+                  url: "",
+                  sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                },
               ],
               label: [0,0,2]
             }
@@ -771,6 +817,7 @@ describe("SingleEditionMintable", () => {
               "https://arweave.net/fnfNerUHj64h-J2yU9d-rZ6ZBAQRhrWfkw_fgiKyl2k?id=1"
               + `&address=${minterContract.address.toLowerCase()}`,
             media_version: "0.0.2",
+            patch_notes: "",
             properties: { number: 1, name: "Testing Token" },
           })
         );


### PR DESCRIPTION
resolves #4

Adds an extra patch notes url to each version for singleEditionMintable and seededEditionMintable.

@thewhodidthis There would be some breaking changes on the mint form as it would be required  to add a patch notes url. It could be left blank much like the [default version](https://github.com/olta-art/olta-nft-editions/blob/c1a88722a04686e299880a352d15caad3e8585c7/test/SingleEditionMintableTest.ts#L31) in the tests.