### PR TITLE
Add set royalty funds recipient

### DIFF
--- a/contracts/SeededSingleEditionMintable.sol
+++ b/contracts/SeededSingleEditionMintable.sol
@@ -138,7 +138,7 @@ contract SeededSingleEditionMintable is
         // Set edition id start to be 1 not 0
         atEditionId.increment();
 
-        // set defualt royalty fund recipient
+        // set default royalty fund recipient
         royaltyFundsRecipient = _owner;
 
         // Add first version

--- a/contracts/SeededSingleEditionMintable.sol
+++ b/contracts/SeededSingleEditionMintable.sol
@@ -65,6 +65,8 @@ contract SeededSingleEditionMintable is
     */
     event ApprovedMinter(address indexed owner, address indexed minter, bool approved);
 
+    event RoyaltyFundsRecipientChanged(address newRecipientAddress);
+
     // metadata
     string public description;
 
@@ -97,6 +99,8 @@ contract SeededSingleEditionMintable is
     // NFT rendering logic contract
     SharedNFTLogic private immutable sharedNFTLogic;
 
+    address payable royaltyFundsRecipient;
+
     // Global constructor for factory
     constructor(SharedNFTLogic _sharedNFTLogic) {
         sharedNFTLogic = _sharedNFTLogic;
@@ -115,7 +119,8 @@ contract SeededSingleEditionMintable is
            This can be re-assigned or updated later
      */
     function initialize(
-        address _owner,
+        address payable _owner,
+        // TODO: could add royalties recipient to reduce transactions needed
         string memory _name,
         string memory _symbol,
         string memory _description,
@@ -132,6 +137,9 @@ contract SeededSingleEditionMintable is
         royaltyBPS = _royaltyBPS;
         // Set edition id start to be 1 not 0
         atEditionId.increment();
+
+        // set defualt royalty fund recipient
+        royaltyFundsRecipient = _owner;
 
         // Add first version
         versions.addVersion(_version);
@@ -246,6 +254,18 @@ contract SeededSingleEditionMintable is
         allowedMinters[minter] = allowed;
         emit ApprovedMinter(_msgSender(), minter, allowed);
     }
+
+    /**
+      @notice sets a different royalty funds recipient
+      @param newRecipientAddress the new address where royalties will be sent
+     */
+    function setRoyaltyFundsRecipient(address payable newRecipientAddress)
+        external
+        onlyOwner {
+        royaltyFundsRecipient = newRecipientAddress;
+        emit RoyaltyFundsRecipientChanged(newRecipientAddress);
+    }
+
 
     /**
       @dev Updates a url of specified version by the owner of the edition.
@@ -432,10 +452,10 @@ contract SeededSingleEditionMintable is
         override
         returns (address receiver, uint256 royaltyAmount)
     {
-        if (owner() == address(0x0)) {
-            return (owner(), 0);
+        if (royaltyFundsRecipient == address(0)) {
+            return (royaltyFundsRecipient, 0);
         }
-        return (owner(), (_salePrice * royaltyBPS) / 10_000);
+        return (royaltyFundsRecipient, (_salePrice * royaltyBPS) / 10_000);
     }
 
     /**

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -113,7 +113,7 @@ contract SingleEditionMintable is
         editionSize = _editionSize;
         royaltyBPS = _royaltyBPS;
 
-        // set defualt royalty fund recipient
+        // set default royalty fund recipient
         royaltyFundsRecipient = _owner;
 
         // Set edition id start to be 1 not 0

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -48,6 +48,7 @@ contract SingleEditionMintable is
     event VersionURLUpdated(uint8[3] label, uint8 index, string url);
     event VersionAdded(uint8[3] label);
     event ApprovedMinter(address indexed owner, address indexed minter, bool approved);
+    event RoyaltyFundsRecipientChanged(address newRecipientAddress);
 
     // metadata
     string public description;
@@ -76,6 +77,8 @@ contract SingleEditionMintable is
     // NFT rendering logic contract
     SharedNFTLogic private immutable sharedNFTLogic;
 
+    address payable royaltyFundsRecipient;
+
     // Global constructor for factory
     constructor(SharedNFTLogic _sharedNFTLogic) {
         sharedNFTLogic = _sharedNFTLogic;
@@ -94,7 +97,7 @@ contract SingleEditionMintable is
            This can be re-assigned or updated later
      */
     function initialize(
-        address _owner,
+        address payable _owner,
         string memory _name,
         string memory _symbol,
         string memory _description,
@@ -109,6 +112,10 @@ contract SingleEditionMintable is
         description = _description;
         editionSize = _editionSize;
         royaltyBPS = _royaltyBPS;
+
+        // set defualt royalty fund recipient
+        royaltyFundsRecipient = _owner;
+
         // Set edition id start to be 1 not 0
         atEditionId.increment();
 
@@ -222,6 +229,17 @@ contract SingleEditionMintable is
     function setApprovedMinter(address minter, bool allowed) public onlyOwner {
         allowedMinters[minter] = allowed;
         emit ApprovedMinter(_msgSender(), minter, allowed);
+    }
+
+    /**
+      @notice sets a different royalty funds recipient
+      @param newRecipientAddress the new address where royalties will be sent
+     */
+    function setRoyaltyFundsRecipient(address payable newRecipientAddress)
+        external
+        onlyOwner {
+        royaltyFundsRecipient = newRecipientAddress;
+        emit RoyaltyFundsRecipientChanged(newRecipientAddress);
     }
 
     /**
@@ -369,10 +387,10 @@ contract SingleEditionMintable is
         override
         returns (address receiver, uint256 royaltyAmount)
     {
-        if (owner() == address(0x0)) {
-            return (owner(), 0);
+        if (royaltyFundsRecipient == address(0)) {
+            return (royaltyFundsRecipient, 0);
         }
-        return (owner(), (_salePrice * royaltyBPS) / 10_000);
+        return (royaltyFundsRecipient, (_salePrice * royaltyBPS) / 10_000);
     }
 
     /**

--- a/test/SingleEditionMintableTest.ts
+++ b/test/SingleEditionMintableTest.ts
@@ -315,7 +315,7 @@ describe("SingleEditionMintable", () => {
       expect(await minterContract.supportsInterface("0x80ac58cd")).to.be.true;
     });
     describe("royalty 2981", () => {
-      it("follows royalty payout for owner", async () => {
+      it("follows royalty payout for owner recpient", async () => {
         await minterContract.mintEdition(signerAddress);
         // allows royalty payout info to be updated
         expect((await minterContract.royaltyInfo(1, 100))[0]).to.be.equal(
@@ -323,7 +323,7 @@ describe("SingleEditionMintable", () => {
         );
         await minterContract.transferOwnership(await signer1.getAddress());
         expect((await minterContract.royaltyInfo(1, 100))[0]).to.be.equal(
-          await signer1.getAddress()
+          signerAddress // original owner
         );
       });
       it("sets the correct royalty amount", async () => {


### PR DESCRIPTION
solves #18 

Gives the creator the ability to nominate an address e.g 0xSplits, Gnosis Safe to receive the royalties. 

Adds the following:
- a `royaltyFundRecipient` address that defaults to the creator
- functionality for the creator to change the `royaltyFundRecipient`
- changes the royaltyInfo(EIP-2981) to send royalties to the `royaltyFundRecipient`

I haven't updated purchase and withdraw functions. 

Todo:
- [x] discuss: if creator transfers the ownership of the contract the `royaltyFundRecipient` stays the same is this the behaviour desired?

