### PR TITLE
Ensure three urls are added

### DIFF
--- a/contracts/SeededSingleEditionMintable.sol
+++ b/contracts/SeededSingleEditionMintable.sol
@@ -143,8 +143,7 @@ contract SeededSingleEditionMintable is
         royaltyFundsRecipient = _owner;
 
         // Add first version
-        versions.addVersion(_version);
-        emit VersionAdded(_version.label);
+        _addVersion(_version);
     }
 
 
@@ -297,7 +296,7 @@ contract SeededSingleEditionMintable is
         emit VersionURLUpdated(_label, _urlKey, _url);
     }
 
-    /**
+        /**
       @dev Adds new version of the media updating the urls rendered in the metadata.
            The order added determins order stored, the label has no effect.
       @param _version The version to be added consisting of urls, hashes and a label
@@ -305,7 +304,23 @@ contract SeededSingleEditionMintable is
     function addVersion(
         Versions.Version memory _version
     ) public onlyOwner {
+        _addVersion(_version);
+    }
+
+    function _addVersion(
+        Versions.Version memory _version
+    ) internal {
         versions.addVersion(_version);
+
+        // ensure the dynamic array has a length of three
+        if(_version.urls.length < 3){
+            string memory labelKey = sharedNFTLogic.uintArray3ToString(_version.label);
+            for (uint256 i = _version.urls.length; i < 3; i++){
+                // add an empty urlHashPair
+                versions.versions[labelKey].urls.push();
+            }
+        }
+
         emit VersionAdded(_version.label);
     }
 

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -121,8 +121,7 @@ contract SingleEditionMintable is
         atEditionId.increment();
 
         // Add first version
-        versions.addVersion(_version);
-        emit VersionAdded(_version.label);
+        _addVersion(_version);
     }
 
 
@@ -280,9 +279,26 @@ contract SingleEditionMintable is
     function addVersion(
         Versions.Version memory _version
     ) public onlyOwner {
+        _addVersion(_version);
+    }
+
+    function _addVersion(
+        Versions.Version memory _version
+    ) internal {
         versions.addVersion(_version);
+
+        // ensure the dynamic array has a length of three
+        if(_version.urls.length < 3){
+            string memory labelKey = sharedNFTLogic.uintArray3ToString(_version.label);
+            for (uint256 i = _version.urls.length; i < 3; i++){
+                // add an empty urlHashPair
+                versions.versions[labelKey].urls.push();
+            }
+        }
+
         emit VersionAdded(_version.label);
     }
+
 
     function getVersionHistory()
         public

--- a/test/SingleEditionMintableTest.ts
+++ b/test/SingleEditionMintableTest.ts
@@ -565,6 +565,29 @@ describe("SingleEditionMintable", () => {
             ]
           )
         });
+        it("always adds a version with three urls and hashes", async () => {
+          minterContract.addVersion(
+            {
+              urls: [
+                {
+                  url: "only one url",
+                  sha256hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+                }
+              ],
+              label: [0,0,2]
+            },
+          )
+          expect(await minterContract.getURIs()).to.deep.eq(
+            [
+              'only one url',
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+              '',
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+              '',
+              '0x0000000000000000000000000000000000000000000000000000000000000000'
+            ]
+          )
+        })
         it("adds large number of versions", async () => {
           const versions: Label[] = []
           // populate versions // 10 * 5 * 2 = 100


### PR DESCRIPTION
solves #25 by ensuring when adding a version that there is alway three urlHashPairs.

This is done by checking the length of the version.urls array and pushing empty urlHahsPairs.

This allows for the correct rendering of metadata