### PR TITLE
Creator white listing

### DIFF
--- a/contracts/ProjectCreator.sol
+++ b/contracts/ProjectCreator.sol
@@ -1,15 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0
-
-/**
-
-█▄░█ █▀▀ ▀█▀   █▀▀ █▀▄ █ ▀█▀ █ █▀█ █▄░█ █▀
-█░▀█ █▀░ ░█░   ██▄ █▄▀ █ ░█░ █ █▄█ █░▀█ ▄█
-
-▀█ █▀█ █▀█ ▄▀█
-█▄ █▄█ █▀▄ █▀█
-
- */
-
 pragma solidity ^0.8.6;
 
 import {ClonesUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
@@ -53,7 +42,6 @@ contract ProjectCreator {
     mapping(uint8 => CountersUpgradeable.Counter) private atContracts;
 
     /// Address for implementation of SingleEditionMintable to clone
-    // TODO: a mapping with implementation name may clearer?
     address[] public implementations;
 
     /// Initializes factory with address of implementations logic
@@ -81,7 +69,6 @@ contract ProjectCreator {
             bytes32(abi.encodePacked(newId))
         );
 
-        // Editions
         IProject(newContract).initialize(
             msg.sender,
             projectData.name,
@@ -106,8 +93,8 @@ contract ProjectCreator {
         return newId;
     }
 
-    /// Get edition given the created ID
-    /// @param projectId id of edition to get contract for
+    /// Get project given the created ID
+    /// @param projectId id of the project to get
     /// @return project the contract of the project
     function getProjectAtId(uint256 projectId, uint8 implementation)
         external
@@ -145,13 +132,13 @@ contract ProjectCreator {
         uint8 implementation
     );
 
-    /// Emitted when a edition is created reserving the corresponding token IDs.
-    /// @param editionId ID of newly created edition
+    /// Emitted when a project is created reserving the corresponding token IDs.
+    /// @param projectId ID of newly created edition
     event CreatedProject(
-        uint256 indexed editionId,
+        uint256 indexed projectId,
         address indexed creator,
         uint256 editionSize,
-        address editionContractAddress,
+        address project,
         uint8 implementation
     );
 }

--- a/test/ProjectCreatorTests.ts
+++ b/test/ProjectCreatorTests.ts
@@ -46,27 +46,27 @@ const defualtProjectData = projectData(
 )
 
 describe("ProjectCreator", () => {
-  let signer: SignerWithAddress
+  let admin: SignerWithAddress
   let creator: SignerWithAddress
-  let creatorContract: ProjectCreator
+  let ProjectCreator: ProjectCreator
 
   beforeEach(async () => {
-    const { ProjectCreator } = await deployments.fixture([
+    const { ProjectCreator: ProjectCreatorContract } = await deployments.fixture([
       "ProjectCreator",
     ]);
 
-    creatorContract = (await ethers.getContractAt(
+    ProjectCreator = (await ethers.getContractAt(
       "ProjectCreator",
-      ProjectCreator.address
+      ProjectCreatorContract.address
     )) as ProjectCreator
 
-    [signer, creator] = await ethers.getSigners()
+    [admin, creator] = await ethers.getSigners()
   })
 
   describe("#createProject", () => {
     it("reverts if not an approved creator", async () => {
       await expect(
-        creatorContract.connect(creator).createProject(
+        ProjectCreator.connect(creator).createProject(
           defualtProjectData,
           Implementation.standard
         )
@@ -74,11 +74,11 @@ describe("ProjectCreator", () => {
     })
 
     it("creates new edition with StandardProject implementation", async () => {
-      await creatorContract.createProject(
+      await ProjectCreator.createProject(
         defualtProjectData,
         Implementation.standard
       )
-      const editionConractAddress01 = await creatorContract.getProjectAtId(0, Implementation.standard)
+      const editionConractAddress01 = await ProjectCreator.getProjectAtId(0, Implementation.standard)
       const editionsContract01 = (await ethers.getContractAt(
         "StandardProject",
         editionConractAddress01
@@ -91,11 +91,11 @@ describe("ProjectCreator", () => {
     })
 
     it("creates new edition with seededProject implementation", async () => {
-      await creatorContract.createProject(
+      await ProjectCreator.createProject(
         defualtProjectData,
         Implementation.seeded
       )
-      const editionConractAddress02 = await creatorContract.getProjectAtId(0, Implementation.seeded)
+      const editionConractAddress02 = await ProjectCreator.getProjectAtId(0, Implementation.seeded)
       const editionsContract02 = (await ethers.getContractAt(
         "SeededProject",
         editionConractAddress02
@@ -110,42 +110,42 @@ describe("ProjectCreator", () => {
     it("should increment a seperate id counter for each implementation", async () => {
 
        // create first edition
-      await creatorContract.createProject(
+      await ProjectCreator.createProject(
         defualtProjectData,
         Implementation.standard
       )
 
       // create second edition
-      let expectedAddress = await creatorContract.getProjectAtId(1, Implementation.standard)
+      let expectedAddress = await ProjectCreator.getProjectAtId(1, Implementation.standard)
       await expect(
-        creatorContract.createProject(
+        ProjectCreator.createProject(
           defualtProjectData,
           Implementation.standard
         )
       ).to.emit(
-        creatorContract,
+        ProjectCreator,
         "CreatedProject"
       ).withArgs(
           1,                // id
-          signer.address,    // creator
+          admin.address,    // creator
           10,               // edition size
           expectedAddress,
           Implementation.standard
         )
 
       // create first seeded edition
-      expectedAddress = await creatorContract.getProjectAtId(0, Implementation.seeded)
+      expectedAddress = await ProjectCreator.getProjectAtId(0, Implementation.seeded)
       await expect(
-        creatorContract.createProject(
+        ProjectCreator.createProject(
           defualtProjectData,
           Implementation.seeded
         )
       ).to.emit(
-        creatorContract,
+        ProjectCreator,
         "CreatedProject"
       ).withArgs(
           0,              // id
-          signer.address,  // creator
+          admin.address,  // creator
           10,             // edition size
           expectedAddress,
           Implementation.seeded
@@ -153,7 +153,7 @@ describe("ProjectCreator", () => {
     })
     it("reverts if implementation doesn't exist", async () => {
       await expect(
-        creatorContract.createProject(
+        ProjectCreator.createProject(
           defualtProjectData,
           3
         )
@@ -162,29 +162,29 @@ describe("ProjectCreator", () => {
 
     it("can be called by anyone when zero address approved", async () => {
       await expect(
-        creatorContract.connect(creator).createProject(
+        ProjectCreator.connect(creator).createProject(
           defualtProjectData,
           Implementation.standard
         )
       ).to.be.revertedWith("Only approved creators can call this function.")
 
-      await creatorContract.setCreatorApprovals([
+      await ProjectCreator.setCreatorApprovals([
         createApproval(ethers.constants.AddressZero, true)
       ])
 
       await expect(
-        creatorContract.connect(creator).createProject(
+        ProjectCreator.connect(creator).createProject(
           defualtProjectData,
           Implementation.standard
         )
-      ).to.emit(creatorContract, "CreatedProject")
+      ).to.emit(ProjectCreator, "CreatedProject")
     })
   })
 
   describe("#addImplementation", () => {
     let newImplementation: StandardProject
 
-    const deployImplementation = async (s = signer) => {
+    const deployImplementation = async (s = admin) => {
       // deploy another Standard Project contract
       const { SharedNFTLogic } = await deployments.fixture(["SharedNFTLogic"])
       const StandardProject = await ethers.getContractFactory("StandardProject")
@@ -201,14 +201,14 @@ describe("ProjectCreator", () => {
     it("reverts if not deployer of contract", async () => {
       const notOwner = (await ethers.getSigners())[1]
       await expect(
-        creatorContract.connect(notOwner).addImplementation(newImplementation.address)
+        ProjectCreator.connect(notOwner).addImplementation(newImplementation.address)
       ).to.be.revertedWith("Only owner can call this function.")
     })
 
     it("adds an implementation", async () => {
-      await creatorContract.addImplementation(newImplementation.address)
+      await ProjectCreator.addImplementation(newImplementation.address)
       expect(
-        await creatorContract.implementations(2)
+        await ProjectCreator.implementations(2)
       ).to.be.equal(newImplementation.address)
     })
 
@@ -224,23 +224,23 @@ describe("ProjectCreator", () => {
       )
 
       // add 3rd implementation
-      await creatorContract.addImplementation(newImplementation.address)
+      await ProjectCreator.addImplementation(newImplementation.address)
       expect(
-        await creatorContract.implementations(2)
+        await ProjectCreator.implementations(2)
       ).to.be.equal(newImplementation.address)
 
       // add 4th implementation
-      await creatorContract.addImplementation(anotherNewImplementation.address)
+      await ProjectCreator.addImplementation(anotherNewImplementation.address)
       expect(
-        await creatorContract.implementations(3)
+        await ProjectCreator.implementations(3)
       ).to.be.equal(anotherNewImplementation.address)
     })
 
     it("emits ImplemnetationAdded event", async () => {
       await expect(
-        creatorContract.addImplementation(newImplementation.address)
+        ProjectCreator.addImplementation(newImplementation.address)
       ).to.emit(
-        creatorContract,
+        ProjectCreator,
         "ImplemnetationAdded"
       ).withArgs(
         newImplementation.address,
@@ -253,7 +253,7 @@ describe("ProjectCreator", () => {
   describe("#setCreatorApprovals", () => {
     it("reverts if not owner", async () => {
       await expect(
-        creatorContract.connect(creator).setCreatorApprovals([
+        ProjectCreator.connect(creator).setCreatorApprovals([
           createApproval(creator.address, true)
         ])
       ).to.be.revertedWith("Only owner can call this function.")
@@ -262,52 +262,52 @@ describe("ProjectCreator", () => {
     it("sets approval for creator", async () => {
       // creator can't create a project
       await expect(
-        creatorContract.connect(creator).createProject(
+        ProjectCreator.connect(creator).createProject(
           defualtProjectData,
           Implementation.standard
         )
       ).to.be.reverted
 
       // approve creator
-      await creatorContract.setCreatorApprovals([
+      await ProjectCreator.setCreatorApprovals([
         createApproval(creator.address, true)
       ])
 
       // creator can now create projects
       expect(
-        await creatorContract.connect(creator).createProject(
+        await ProjectCreator.connect(creator).createProject(
           defualtProjectData,
           Implementation.standard
         )
-      ).to.emit(creatorContract, "CreatedProject")
+      ).to.emit(ProjectCreator, "CreatedProject")
     })
 
     it("sets approval for creators", async () => {
       // creator can't create a project
       await expect(
-        creatorContract.connect(creator).createProject(
+        ProjectCreator.connect(creator).createProject(
           defualtProjectData,
           Implementation.standard
         )
       ).to.be.reverted
 
       // approve creator
-      await creatorContract.setCreatorApprovals([
+      await ProjectCreator.setCreatorApprovals([
         createApproval(creator.address, true),
-        createApproval(signer.address, false),
+        createApproval(admin.address, false),
       ])
 
       // creator can now create projects
       await expect(
-        creatorContract.connect(creator).createProject(
+        ProjectCreator.connect(creator).createProject(
           defualtProjectData,
           Implementation.standard
         )
-      ).to.emit(creatorContract, "CreatedProject")
+      ).to.emit(ProjectCreator, "CreatedProject")
 
       // signer can now create projects
       await expect(
-       creatorContract.connect(signer).createProject(
+       ProjectCreator.connect(admin).createProject(
           defualtProjectData,
           Implementation.standard
         )
@@ -315,9 +315,9 @@ describe("ProjectCreator", () => {
     })
     it("emits a list of creator approval updates", async () => {
 
-      const tx = await creatorContract.setCreatorApprovals([
+      const tx = await ProjectCreator.setCreatorApprovals([
         createApproval(creator.address, true),
-        createApproval(signer.address, true),
+        createApproval(admin.address, true),
       ])
 
       const recpient = await tx.wait()
@@ -331,7 +331,7 @@ describe("ProjectCreator", () => {
             true
           ],
           [
-            signer.address,
+            admin.address,
             true
           ]
         ]

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,6 @@
 import {utils , BigNumberish} from "ethers"
 import {URL} from "url"
+import { Address } from "hardhat-deploy/dist/types";
 export const getSeed = (tokenId: number, tokenAddress: string) => {
   const hash = utils.keccak256(
     utils.concat([
@@ -25,6 +26,8 @@ export const parseUrlQuery = (url: string) => {
     address
   }
 }
+
+export const createApproval = (id: Address, approval: boolean) => ({id, approval})
 
 export enum Implementation {
   standard,


### PR DESCRIPTION
adds white listing functionality to the "owner" of the projectCreator contract. 
The owner will be the wallet address that deployed the contract. (olta)

resolves #31 

- adds a `onlyCreator` modifyer to the `createProject` function
- adds `setCreatorApprovals` function to be able to set the approval of a list wallet address.
- setting the zero address `creatorApproval` to true allows anyone to create a project.
- emits an event when approvals are updated
- added tests




