### PR TITLE
Make project creator ownable and clean up

### DIFF
--- a/contracts/Projects/Seeded.sol
+++ b/contracts/Projects/Seeded.sol
@@ -14,15 +14,16 @@ import {ISeededProject, MintData} from "./ISeeded.sol";
 /**
     This is a smart contract for handling dynamic contract minting.
 
-    This is a fork of Zora NFT Editions
-    changes:
-        - Media urls are versioned allowing for updatable content preserving history
-        - The NFT contract address is included in edition url query for easyier access to query the graph from within the NFT
-        - SupportsInterface function includes project implementation interface
+    The contract is based on Zora NFT Editions: https://github.com/ourzora/nft-editions
+
+    - Content urls are versioned allowing for updatable content preserving history
+    - The project contract address is included in edition url for easyier access to query the graph from within the NFT
+    - SupportsInterface function includes project implementation interface
+    - A seed number is chosen on the minting of editions
 
     @dev This allows creators to mint a unique serial edition of the same media within a custom contract
-    @author iain nash
-    Repository: https://github.com/ourzora/nft-editions
+    @author george baldwin
+    Repository: https://github.com/olta-art/olta-nft-editions
 */
 contract SeededProject is
     ERC721Upgradeable,
@@ -110,7 +111,6 @@ contract SeededProject is
      */
     function initialize(
         address payable _owner,
-        // TODO: could add royalties recipient to reduce transactions needed
         string memory _name,
         string memory _symbol,
         string memory _description,

--- a/contracts/Projects/Standard.sol
+++ b/contracts/Projects/Standard.sol
@@ -16,15 +16,15 @@ import {IStandardProject} from "./IStandard.sol";
 /**
     This is a smart contract for handling dynamic contract minting.
 
-    This is a fork of Zora NFT Editions
-    changes:
-        - Media urls are versioned allowing for updatable content preserving history
-        - The NFT contract address is included in edition url query for easyier access to query the graph from within the NFT
-        - SupportsInterface function includes project implementation interface
+    The contract is based on Zora NFT Editions: https://github.com/ourzora/nft-editions
+
+    - Content urls are versioned allowing for updatable content preserving history
+    - The project contract address is included in edition url for easyier access to query the graph from within the NFT
+    - SupportsInterface function includes project implementation interface
 
     @dev This allows creators to mint a unique serial edition of the same media within a custom contract
-    @author iain nash
-    Repository: https://github.com/ourzora/nft-editions
+    @author george baldwin
+    Repository: https://github.com/olta-art/olta-nft-editions
 */
 contract StandardProject is
     ERC721Upgradeable,

--- a/contracts/Versions.sol
+++ b/contracts/Versions.sol
@@ -3,9 +3,6 @@
 pragma solidity 0.8.6;
 
 import {StringsUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
-/*
-    please note this is work in progress and not ready for production just yet
-*/
 
 /**
  @title A libary for versioning of NFT content and metadata
@@ -16,6 +13,7 @@ import {StringsUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Stri
  Include with `using Versions for Versions.set;`
  @author george baldwin
  */
+
 library Versions {
 
     struct UrlHashPair {

--- a/deploy/05_projectcreator.ts
+++ b/deploy/05_projectcreator.ts
@@ -7,7 +7,13 @@ module.exports = async ({ getNamedAccounts, deployments }: any) => {
 
   await deploy("ProjectCreator", {
     from: deployer,
-    args: [[mintableAddress, seededMintableAddress]],
+    proxy: {
+      proxyContract: 'OpenZeppelinTransparentProxy',
+      execute: {
+        methodName: "initialize",
+        args: [[mintableAddress, seededMintableAddress]]
+      }
+    },
     log: true,
   });
 };

--- a/test/ProjectCreatorTests.ts
+++ b/test/ProjectCreatorTests.ts
@@ -202,7 +202,7 @@ describe("ProjectCreator", () => {
       const notOwner = (await ethers.getSigners())[1]
       await expect(
         ProjectCreator.connect(notOwner).addImplementation(newImplementation.address)
-      ).to.be.revertedWith("Only owner can call this function.")
+      ).to.be.revertedWith("Ownable: caller is not the owner")
     })
 
     it("adds an implementation", async () => {
@@ -256,7 +256,7 @@ describe("ProjectCreator", () => {
         ProjectCreator.connect(creator).setCreatorApprovals([
           createApproval(creator.address, true)
         ])
-      ).to.be.revertedWith("Only owner can call this function.")
+      ).to.be.revertedWith("Ownable: caller is not the owner")
     })
 
     it("sets approval for creator", async () => {
@@ -339,4 +339,26 @@ describe("ProjectCreator", () => {
     })
   })
 
+  describe("#transferOwnership (OwnableUpgradable)", () => {
+    it("transfers ownership", async () => {
+      expect(
+        await ProjectCreator.connect(admin).transferOwnership(creator.address)
+      ).to.emit(
+        ProjectCreator, "OwnershipTransferred"
+      ).withArgs(admin.address, creator.address)
+
+      const zeroApproval = [{
+        id: ethers.constants.AddressZero,
+        approval: true
+      }]
+
+      await expect(
+        ProjectCreator.connect(admin).setCreatorApprovals(zeroApproval)
+      ).to.be.reverted
+
+      await expect(
+        ProjectCreator.connect(creator).setCreatorApprovals(zeroApproval)
+      ).to.not.be.reverted
+    })
+  })
 })


### PR DESCRIPTION
To allow for the use of Gnosis safe with project creator task we need the projectCreator contract to be transferable. 

- adds OwnableUpgradeable to project creator
- adds transfer test
- cleans up comments and todo's